### PR TITLE
[feature] New `getVersion(String, Configuration)` function

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @palantir/infrastructure

--- a/README.md
+++ b/README.md
@@ -263,3 +263,26 @@ This plugin requires the settings.gradle to declare a `rootProject.name` which i
  include 'sls-status-api:sls-status-api-objects'
  include 'sls-status-dropwizard'
 ```
+
+#### What about `dependencyRecommendations.getRecommendedVersion`?
+
+If you rely on this Nebula function, then gradle-consistent-versions has a similar alternative:
+
+```diff
+-println dependencyRecommendations.getRecommendedVersion('com.google.guava:guava')
++println getVersion('com.google.guava:guava')
+```
+
+Note that you can't invoke this function at configuration time (e.g. in the body of a task declaration), because the plugin needs to resolve dependencies to return the answer and Gradle [strongly discourages](https://guides.gradle.org/performance/#don_t_resolve_dependencies_at_configuration_time) resolving dependencies at configuration time.
+
+Alternatives:
+
+- if you rely on this function for sls-packaging `productDependencies`, use `detectConstraints = true` or upgrade to 3.X
+- if you rely on this function to configure the `from` or `to` parameters of a `Copy` task, use a closure or move the whole thing into a doLast block.
+
+```diff
+ task copySomething(type: Copy) {
+-    from "$buildDir/foo/bar-${dependencyRecommendations.getRecommendedVersion('group:bar')}"
++    from { "$buildDir/foo/bar-${getVersion('group:bar')}" }
+     ...
+```

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -28,5 +28,6 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
         }
         project.getPluginManager().apply(VersionsLockPlugin.class);
         project.getPluginManager().apply(VersionsPropsPlugin.class);
+        project.getPluginManager().apply(GetVersionPlugin.class);
     }
 }

--- a/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
@@ -23,6 +23,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import groovy.lang.Closure;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -36,7 +37,13 @@ public final class GetVersionPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getExtensions().getExtraProperties().set("getVersion", new Closure<String>(project, project) {
 
-            public String doCall(Object moduleVersion, Configuration configuration) {
+            public String doCall(Object moduleVersion) {
+                return doCall(moduleVersion, project.getRootProject()
+                        .getConfigurations()
+                        .getByName(VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME));
+            }
+
+            public String doCall(Object moduleVersion, @Nullable Configuration configuration) {
                 List<String> strings = Splitter.on(':').splitToList(moduleVersion.toString());
                 Preconditions.checkState(
                         strings.size() == 2,

--- a/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
@@ -49,11 +49,7 @@ public final class GetVersionPlugin implements Plugin<Project> {
                         "Expected 'group:name', found: %s",
                         moduleVersion.toString());
 
-                return getVersion(
-                        project,
-                        strings.get(0),
-                        strings.get(1),
-                        configuration);
+                return getVersion(project, strings.get(0), strings.get(1), configuration);
             }
         });
     }

--- a/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
@@ -1,0 +1,84 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions;
+
+import static java.util.stream.Collectors.toList;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import groovy.lang.Closure;
+import java.util.List;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+
+public final class GetVersionPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getExtensions().getExtraProperties().set("getVersion", new Closure<String>(project, project){
+
+            public String doCall(Object arg) {
+                Preconditions.checkNotNull(arg, "getVersion() requires arguments,"
+                        + " e.g. getVersion('com.google.guava:guava') or getVersion('com.google.guava:guava', "
+                        + "configurations.runtimeClasspath)");
+
+                return doCall(arg, project.getConfigurations().getByName("runtimeClasspath"));
+            }
+
+            public String doCall(Object moduleVersion, Configuration configuration) {
+                List<String> strings = Splitter.on(':').splitToList(moduleVersion.toString());
+                Preconditions.checkState(
+                        strings.size() == 2,
+                        "Expected 'group:name', found: " + moduleVersion.toString());
+
+                return getVersion(
+                        strings.get(0),
+                        strings.get(1),
+                        configuration);
+            }
+        });
+    }
+
+    private static String getVersion(String group, String name, Configuration configuration) {
+        List<ModuleVersionIdentifier> list =
+                configuration.getIncoming().getResolutionResult().getAllComponents().stream()
+                        .map(ResolvedComponentResult::getModuleVersion)
+                        .filter(item -> item.getGroup().equals(group) && item.getName().equals(name))
+                        .collect(toList());
+
+        if (list.isEmpty()) {
+            List<ModuleVersionIdentifier> actual =
+                    configuration.getIncoming().getResolutionResult().getAllComponents().stream()
+                            .map(ResolvedComponentResult::getModuleVersion)
+                            .collect(toList());
+            throw new GradleException(String.format("Unable to find '%s:%s' in %s: %s",
+                    group, name, configuration, actual));
+        }
+
+        if (list.size() > 1) {
+            throw new GradleException(String.format("Multiple modules matching '%s:%s' in %s: %s",
+                    group, name, configuration, list));
+        }
+
+        return Iterables.getOnlyElement(list).getVersion();
+    }
+}

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -93,4 +93,23 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationTestKitSpec {
         expect:
         runTasks('demo').output.contains("demo=1.7.25")
     }
+
+    def "getVersion function works even when writing locks"() {
+        buildFile << '''
+            repositories { jcenter() }
+            apply plugin: 'java'
+            dependencies {
+                compile 'org.slf4j:slf4j-api'
+            }
+
+            task demo {
+                doLast { println "demo=" + getVersion('org.slf4j:slf4j-api') }
+            }
+        '''.stripIndent()
+
+        file('versions.props') << 'org.slf4j:* = 1.7.25'
+
+        expect:
+        runTasks('demo', '--write-locks').output.contains("demo=1.7.25")
+    }
 }

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -74,4 +74,23 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationTestKitSpec {
         runTasks('resolveConfigurations', '--write-locks')
         runTasks('resolveConfigurations')
     }
+
+    def "getVersion function works"() {
+        buildFile << '''
+            repositories { jcenter() }
+            apply plugin: 'java'
+            dependencies {
+                compile 'org.slf4j:slf4j-api'
+            }
+
+            task demo {
+                doLast { println "demo=" + getVersion('org.slf4j:slf4j-api', configurations.compileClasspath) }
+            }
+        '''.stripIndent()
+
+        file('versions.props') << 'org.slf4j:* = 1.7.25'
+
+        expect:
+        runTasks('demo').output.contains("demo=1.7.25")
+    }
 }

--- a/src/test/groovy/com/palantir/gradle/versions/GetVersionPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/GetVersionPluginIntegrationSpec.groovy
@@ -1,0 +1,64 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions
+
+
+import nebula.test.ProjectSpec
+import org.gradle.api.GradleException
+import org.gradle.api.plugins.JavaPlugin
+
+class GetVersionPluginIntegrationSpec extends ProjectSpec {
+
+    def 'apply does not throw exceptions'() {
+        when:
+        project.apply plugin: GetVersionPlugin
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'apply is idempotent'() {
+        when:
+        project.apply plugin: GetVersionPlugin
+        project.apply plugin: GetVersionPlugin
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'function is callable from groovy with one arg'() {
+        when:
+        project.apply plugin: GetVersionPlugin
+        project.apply plugin: JavaPlugin
+        project.ext.getVersion('com.google.guava:guava')
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains "Unable to find 'com.google.guava:guava' in configuration ':runtimeClasspath'"
+    }
+
+    def 'function is callable from groovy with two args'() {
+        when:
+        project.apply plugin: GetVersionPlugin
+        project.apply plugin: JavaPlugin
+        project.ext.getVersion('com.google.guava:guava', project.configurations.compile)
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains "Unable to find 'com.google.guava:guava' in configuration ':compile'"
+    }
+}

--- a/src/test/groovy/com/palantir/gradle/versions/GetVersionPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/GetVersionPluginIntegrationSpec.groovy
@@ -40,17 +40,6 @@ class GetVersionPluginIntegrationSpec extends ProjectSpec {
         noExceptionThrown()
     }
 
-    def 'function is callable from groovy with one arg'() {
-        when:
-        project.apply plugin: GetVersionPlugin
-        project.apply plugin: JavaPlugin
-        project.ext.getVersion('com.google.guava:guava')
-
-        then:
-        def ex = thrown(GradleException)
-        ex.message.contains "Unable to find 'com.google.guava:guava' in configuration ':runtimeClasspath'"
-    }
-
     def 'function is callable from groovy with two args'() {
         when:
         project.apply plugin: GetVersionPlugin

--- a/src/test/groovy/com/palantir/gradle/versions/GetVersionPluginSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/GetVersionPluginSpec.groovy
@@ -21,7 +21,7 @@ import nebula.test.ProjectSpec
 import org.gradle.api.GradleException
 import org.gradle.api.plugins.JavaPlugin
 
-class GetVersionPluginIntegrationSpec extends ProjectSpec {
+class GetVersionPluginSpec extends ProjectSpec {
 
     def 'apply does not throw exceptions'() {
         when:


### PR DESCRIPTION
## Before this PR

People are using nebula's `dependencyRecommendations.getRecommendedVersion` thing all over the place

## After this PR

We make an acceptable workaround available, and recommend people delete all other usages of that function.