### PR TITLE
[improvement] Full stacktrace of resolution exceptions when -S

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.versions;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.MapDifference.ValueDifference;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Streams;
 import com.palantir.configurationresolver.ConfigurationResolverPlugin;
 import com.palantir.configurationresolver.ResolveConfigurationsTask;
 import com.palantir.gradle.versions.internal.MyModuleIdentifier;
@@ -33,6 +35,8 @@ import com.palantir.gradle.versions.lockstate.FullLockState;
 import com.palantir.gradle.versions.lockstate.Line;
 import com.palantir.gradle.versions.lockstate.LockState;
 import com.palantir.gradle.versions.lockstate.LockStates;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -47,6 +51,7 @@ import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.inject.Inject;
 import netflix.nebula.dependency.recommender.RecommendationStrategies;
 import netflix.nebula.dependency.recommender.provider.RecommendationProviderContainer;
 import org.gradle.api.GradleException;
@@ -68,8 +73,10 @@ import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.api.plugins.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
@@ -95,6 +102,13 @@ public class VersionsLockPlugin implements Plugin<Project> {
      */
     private static final Attribute<String> COMPONENT_CATEGORY =
             Attribute.of("org.gradle.component.category", String.class);
+
+    private final ShowStacktrace showStacktrace;
+
+    @Inject
+    public VersionsLockPlugin(Gradle gradle) {
+        showStacktrace = gradle.getStartParameter().getShowStacktrace();
+    }
 
     @NotNull
     static Path getRootLockFile(Project project) {
@@ -301,7 +315,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
      * lazy, so recursive calls don't actually execute right away, but are executed when those configurations are
      * evaluated.
      */
-    private static void resolveDependentPublications(
+    private void resolveDependentPublications(
             Project currentProject, DependencySet dependencySet, Map<Configuration, String> copiedConfigurationsCache) {
         dependencySet
                 .matching(dependency -> ProjectDependency.class.isAssignableFrom(dependency.getClass()))
@@ -362,7 +376,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 && project.getGroup().equals(subproject.getGroup());
     }
 
-    private static void failIfAnyDependenciesUnresolved(ResolvableDependencies resolvableDependencies) {
+    private void failIfAnyDependenciesUnresolved(ResolvableDependencies resolvableDependencies) {
         List<UnresolvedDependencyResult> unresolved = resolvableDependencies
                 .getResolutionResult()
                 .getAllDependencies()
@@ -376,7 +390,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
                     UNIFIED_CLASSPATH_CONFIGURATION_NAME,
                     unresolved
                             .stream()
-                            .map(VersionsLockPlugin::formatUnresolvedDependencyResult)
+                            .map(this::formatUnresolvedDependencyResult)
                             .collect(Collectors.joining("\n"))));
         }
     }
@@ -432,11 +446,20 @@ public class VersionsLockPlugin implements Plugin<Project> {
      * {@link org.gradle.api.tasks.diagnostics.internal.insight.DependencyInsightReporter#collectErrorMessages}
      * does, since that whole class is not public API.
      */
-    private static String formatUnresolvedDependencyResult(UnresolvedDependencyResult result) {
+    private String formatUnresolvedDependencyResult(UnresolvedDependencyResult result) {
         StringBuilder failures = new StringBuilder();
         for (Throwable failure = result.getFailure(); failure != null; failure = failure.getCause()) {
             failures.append("         - ");
             failures.append(failure.getMessage());
+            if (showStacktrace == ShowStacktrace.ALWAYS_FULL) {
+                failures.append("\n");
+                StringWriter out = new StringWriter();
+                failure.printStackTrace(new PrintWriter(out));
+                Streams
+                        .stream(Splitter.on('\n').split(out.getBuffer()))
+                        .map(line -> "           " + line + "\n")
+                        .forEachOrdered(failures::append);
+            }
             failures.append("\n");
         }
         return String.format(" * %s (requested: '%s' because: %s)\n      Failures:\n%s",


### PR DESCRIPTION
## Before this PR

You can't see the stacktrace of resolution exceptions coming from unresolved dependencies of `unifiedClasspath`.
Usually that's fine, but difficult when debugging some issue with exceptions.

## After this PR

If `-S` (full stacktrace) flag is provided, print out the stacktrace of each resolution failure found in `unifiedClasspath`'s resolution result.
This helps debug more complex errors when they occur.