### PR TITLE
[fix] Write locks could fail under certain conditions

### DIFF
--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -369,4 +369,33 @@ class VersionsLockPluginIntegrationSpec extends IntegrationTestKitSpec {
         result.output.contains('org.slf4j:slf4j-api:1.7.25')
         result.output.contains('ch.qos.logback:logback-classic -> 1.7.25')
     }
+
+    def 'does not fail if subproject evaluated later applies base plugin in own build file'() {
+        buildFile << """
+            allprojects {             
+                repositories { jcenter() } 
+            }
+        """.stripIndent()
+
+        addSubproject('foo', """
+            apply plugin: 'java-library'
+            dependencies {
+                implementation project(':foo:bar')
+            }
+        """.stripIndent())
+
+        // Need to make sure bar is evaluated after foo, so we're nesting it!
+        def subdir = new File(projectDir, 'foo/bar')
+        subdir.mkdirs()
+        settingsFile << "include ':foo:bar'"
+        new File(subdir, 'build.gradle') << """
+            apply plugin: 'java-library'
+            dependencies {
+                implementation 'org.slf4j:slf4j-api:1.7.24'
+            }
+        """.stripIndent()
+
+        expect:
+        runTasks('--write-locks')
+    }
 }

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -390,9 +390,6 @@ class VersionsLockPluginIntegrationSpec extends IntegrationTestKitSpec {
         settingsFile << "include ':foo:bar'"
         new File(subdir, 'build.gradle') << """
             apply plugin: 'java-library'
-            dependencies {
-                implementation 'org.slf4j:slf4j-api:1.7.24'
-            }
         """.stripIndent()
 
         expect:


### PR DESCRIPTION
## Before this PR

Write locks could fail like so, if projects end up being evaluated in a particularly pathological order and some other conditions are true:

```
* What went wrong:
A problem occurred evaluating project ':foo:bar'.
> Failed to apply plugin [class 'org.gradle.api.plugins.BasePlugin']
   > DefaultDomainObjectSet#add(T) on [DefaultProjectDependency{dependencyProject='root project 'does-not-fail-if-subproject-evaluated-later-applies-base-plugin-in-own-build-file'', configuration='subprojectUnifiedClasspathCopy'}, DefaultProjectDependency{dependencyProject='project ':foo'', configuration='subprojectUnifiedClasspathCopy'}] cannot be executed in the current context.
```

Specifically, if
* subproject A depends on subproject B, 
* B applies the `base` plugin in its `build.gradle` (as opposed to the root project's build file configuring `project('b') { apply plugin: 'base' }`), 
* A is configured before B when calling `rootProject.allprojects`

Then you'd get the above error.

## After this PR

Fixed that failure case, and added a test to guard against it.