### PR TITLE
[improvement] getVersion(String, String) signature allows easier adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Alternatives:
 
 ```diff
  task copySomething(type: Copy) {
--    from "$buildDir/foo/bar-${dependencyRecommendations.getRecommendedVersion('group:bar')}"
-+    from { "$buildDir/foo/bar-${getVersion('group:bar')}" }
+-    from "$buildDir/foo/bar-${dependencyRecommendations.getRecommendedVersion('group', 'bar')}"
++    from { "$buildDir/foo/bar-${getVersion('group', 'bar')}" }
      ...
 ```

--- a/README.md
+++ b/README.md
@@ -286,6 +286,6 @@ Alternatives:
 ```diff
  task copySomething(type: Copy) {
 -    from "$buildDir/foo/bar-${dependencyRecommendations.getRecommendedVersion('group', 'bar')}"
-+    from { "$buildDir/foo/bar-${getVersion('group', 'bar')}" }
++    from { "$buildDir/foo/bar-${getVersion('group:bar')}" }
      ...
 ```

--- a/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
@@ -36,12 +36,21 @@ public final class GetVersionPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getExtensions().getExtraProperties().set("getVersion", new Closure<String>(project, project) {
 
+            /** Groovy will invoke this method if they just supply one arg, e.g. 'com.google.guava:guava'. */
             public String doCall(Object moduleVersion) {
                 return doCall(moduleVersion, project.getRootProject()
                         .getConfigurations()
                         .getByName(VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME));
             }
 
+            /** This matches the signature of nebula's dependencyRecommendations.getRecommendedVersion. */
+            public String doCall(String group, String name) {
+                return getVersion(project, group, name, project.getRootProject()
+                        .getConfigurations()
+                        .getByName(VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME));
+            }
+
+            /** Find a version from another configuration, e.g. from the gradle-docker plugin. */
             public String doCall(Object moduleVersion, Configuration configuration) {
                 List<String> strings = Splitter.on(':').splitToList(moduleVersion.toString());
                 Preconditions.checkState(

--- a/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
@@ -36,16 +36,12 @@ public final class GetVersionPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getExtensions().getExtraProperties().set("getVersion", new Closure<String>(project, project) {
 
-            /** Groovy will invoke this method if they just supply one arg, e.g. 'com.google.guava:guava'. */
+            /**
+             * Groovy will invoke this method if they just supply one arg, e.g. 'com.google.guava:guava'.
+             * This is the preferred signature because it's shortest.
+             */
             public String doCall(Object moduleVersion) {
                 return doCall(moduleVersion, project.getRootProject()
-                        .getConfigurations()
-                        .getByName(VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME));
-            }
-
-            /** This matches the signature of nebula's dependencyRecommendations.getRecommendedVersion. */
-            public String doCall(String group, String name) {
-                return getVersion(project, group, name, project.getRootProject()
                         .getConfigurations()
                         .getByName(VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME));
             }
@@ -59,6 +55,13 @@ public final class GetVersionPlugin implements Plugin<Project> {
                         moduleVersion.toString());
 
                 return getVersion(project, strings.get(0), strings.get(1), configuration);
+            }
+
+            /** This matches the signature of nebula's dependencyRecommendations.getRecommendedVersion. */
+            public String doCall(String group, String name) {
+                return getVersion(project, group, name, project.getRootProject()
+                        .getConfigurations()
+                        .getByName(VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME));
             }
         });
     }

--- a/src/test/groovy/com/palantir/gradle/versions/GetVersionPluginSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/GetVersionPluginSpec.groovy
@@ -40,7 +40,7 @@ class GetVersionPluginSpec extends ProjectSpec {
         noExceptionThrown()
     }
 
-    def 'function is callable from groovy with two args'() {
+    def 'function is callable from groovy with string & configuration args'() {
         when:
         project.apply plugin: GetVersionPlugin
         project.apply plugin: JavaPlugin
@@ -49,5 +49,17 @@ class GetVersionPluginSpec extends ProjectSpec {
         then:
         def ex = thrown(GradleException)
         ex.message.contains "Unable to find 'com.google.guava:guava' in configuration ':compile'"
+    }
+
+    def 'function is callable from groovy with two string args'() {
+        when:
+        project.apply plugin: GetVersionPlugin
+        project.apply plugin: JavaPlugin
+        project.getConfigurations().create(VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME)
+        project.ext.getVersion('com.google.guava', 'guava')
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains "Unable to find 'com.google.guava:guava' in configuration ':unifiedClasspath'"
     }
 }


### PR DESCRIPTION
## Before this PR

It was tricky to excavate out the change from nebula -> gradle-consistent-versions because of the `dependencyRecommendations.getRecommendedVersion` function. In nebula it took two args, but in our plugin it took one arg.

## After this PR

our plugin now supports the two-arg signature, so we can excavate people using a simple sed.