### PR TITLE
[improvement] Lock platforms too

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -96,12 +96,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
     private static final String LOCK_CONSTRAINTS_CONFIGURATION_NAME = "lockConstraints";
     private static final Attribute<Boolean> CONSISTENT_VERSIONS_CONSTRAINT_ATTRIBUTE =
             Attribute.of("consistent-versions", Boolean.class);
-    /**
-     * Copied from {@link org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport#COMPONENT_CATEGORY} since
-     * that's internal.
-     */
-    private static final Attribute<String> COMPONENT_CATEGORY =
-            Attribute.of("org.gradle.component.category", String.class);
 
     private final ShowStacktrace showStacktrace;
 
@@ -414,14 +408,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
     private static Optional<Dependents> extractDependents(ResolvedComponentResult component) {
         if (!(component.getId() instanceof ModuleComponentIdentifier)) {
-            return Optional.empty();
-        }
-        // Don't lock any platforms, since these are not actual dependencies.
-        if (component.getDependents().stream().anyMatch(rdr -> {
-            String category = rdr.getRequested().getAttributes().getAttribute(COMPONENT_CATEGORY);
-            return category != null && category.contains("platform");
-        })) {
-            log.debug("Not locking component because it's a platform: {}", component.getId());
             return Optional.empty();
         }
         return Optional.of(Dependents.of(component

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -31,6 +31,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
                 "org.slf4j:slf4j-api:1.7.20",
                 "org.slf4j:slf4j-api:1.7.24",
                 "org.slf4j:slf4j-api:1.7.25",
+                "org:platform:1.0",
         )
         buildFile << """
             plugins { id '${PLUGIN_NAME}' }
@@ -365,9 +366,6 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
     }
 
     def 'does not fail if subproject evaluated later applies base plugin in own build file'() {
-        buildFile << """
-        """.stripIndent()
-
         addSubproject('foo', """
             apply plugin: 'java-library'
             dependencies {
@@ -385,5 +383,23 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         expect:
         runTasks('--write-locks')
+    }
+
+    def "locks platform"() {
+        buildFile << """
+            apply plugin: 'java'
+            dependencies {
+                compile platform('org:platform:1.0')
+            }
+        """.stripIndent()
+
+        when:
+        runTasks('--write-locks')
+
+        then:
+        file('versions.lock').readLines() == [
+                '# Run ./gradlew --write-locks to regenerate this file',
+                'org:platform:1.0 (1 constraints: a5041a2c)',
+        ]
     }
 }


### PR DESCRIPTION
## Before this PR

We were explicitly trying to filter out platforms from the lock file, based on the initial assumption that virtual platforms would show up as platforms in the resolution result.
That has been fixed in gradle 5.1, so now that was only filtering out real published platforms (e.g. boms). It's actually correct to include these platforms and all their dependents in the lock file, as they are real dependencies.

## After this PR

We now include platforms in the lock file.
For users using platform dependencies, a `./gradlew --write-locks` will be necessary in order for their lock file to pick up the platforms that were previously being filtered out.