### PR TITLE
Use local maven repo in integration test rather than jcenter

### DIFF
--- a/src/test/groovy/com/palantir/gradle/versions/IntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/IntegrationSpec.groovy
@@ -1,0 +1,37 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions
+
+import groovy.transform.CompileStatic
+import nebula.test.IntegrationTestKitSpec
+import nebula.test.dependencies.DependencyGraph
+import nebula.test.dependencies.GradleDependencyGenerator
+
+class IntegrationSpec extends IntegrationTestKitSpec {
+    void setup() {
+        keepFiles = true
+        settingsFile.createNewFile()
+    }
+
+    @CompileStatic
+    protected File generateMavenRepo(String... graph) {
+        DependencyGraph dependencyGraph = new DependencyGraph(graph)
+        GradleDependencyGenerator generator = new GradleDependencyGenerator(
+                dependencyGraph, new File(projectDir, "build/testrepogen").toString())
+        return generator.generateTestMavenRepo()
+    }
+}

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -16,19 +16,15 @@
 
 package com.palantir.gradle.versions
 
-import groovy.transform.CompileStatic
-import nebula.test.IntegrationTestKitSpec
 import nebula.test.dependencies.DependencyGraph
 import nebula.test.dependencies.GradleDependencyGenerator
 import org.gradle.testkit.runner.BuildResult
 
-class VersionsLockPluginIntegrationSpec extends IntegrationTestKitSpec {
+class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
     static def PLUGIN_NAME = "com.palantir.versions-lock"
 
     void setup() {
-        keepFiles = true
-        settingsFile.createNewFile()
         File mavenRepo = generateMavenRepo(
                 "ch.qos.logback:logback-classic:1.2.3 -> org.slf4j:slf4j-api:1.7.25",
                 "org.slf4j:slf4j-api:1.7.11",
@@ -390,13 +386,4 @@ class VersionsLockPluginIntegrationSpec extends IntegrationTestKitSpec {
         expect:
         runTasks('--write-locks')
     }
-
-    @CompileStatic
-    File generateMavenRepo(String... graph) {
-        DependencyGraph dependencyGraph = new DependencyGraph(graph)
-        GradleDependencyGenerator generator = new GradleDependencyGenerator(
-                dependencyGraph, new File(projectDir, "build/testrepogen").toString())
-        return generator.generateTestMavenRepo()
-    }
-
 }


### PR DESCRIPTION
## Before this PR

Integration tests were being run against real external repos.

## After this PR

They are now run against internally-generated repos with fake jars, since all we care about is their inter-dependencies.