### PR TITLE
[fix] VersionsPropsPlugin always creates rootConfiguration

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -48,7 +48,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
 
     @Override
     public final void apply(Project project) {
-        checkPreconditions(project);
+        checkPreconditions();
         if (project.getRootProject().equals(project)) {
             applyToRootProject(project);
         }
@@ -196,7 +196,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         return VersionsProps.loadFromFile(versionsPropsFile);
     }
 
-    private static void checkPreconditions(Project project) {
+    private static void checkPreconditions() {
         Preconditions.checkState(
                 GradleVersion.current().compareTo(MINIMUM_GRADLE_VERSION) >= 0,
                 "This plugin requires gradle >= %s",

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.Optional;
 import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
@@ -57,11 +56,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         VersionRecommendationsExtension extension =
                 project.getRootProject().getExtensions().getByType(VersionRecommendationsExtension.class);
 
-        Optional<VersionsProps> versionsProps =
-                computeVersionsProps(project.getRootProject().file("versions.props").toPath());
-        if (!versionsProps.isPresent()) {
-            return;
-        }
+        VersionsProps versionsProps = loadVersionsProps(project.getRootProject().file("versions.props").toPath());
 
         NamedDomainObjectProvider<Configuration> rootConfiguration =
                 project.getConfigurations().register(ROOT_CONFIGURATION_NAME, conf -> {
@@ -69,17 +64,17 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                 });
 
         project.getConfigurations().configureEach(conf ->
-                setupConfiguration(project, extension, rootConfiguration, versionsProps.get(), conf));
+                setupConfiguration(project, extension, rootConfiguration, versionsProps, conf));
 
         // Note: don't add constraints to this, only call `create` / `platform` on it.
         DependencyConstraintHandler constraintHandler = project.getDependencies().getConstraints();
         rootConfiguration.configure(conf ->
-                addVersionsPropsConstraints(constraintHandler, conf, versionsProps.get()));
+                addVersionsPropsConstraints(constraintHandler, conf, versionsProps));
 
         log.info("Configuring rules to assign *-constraints to platforms in {}", project);
         project.getDependencies()
                 .getComponents()
-                .all(component -> tryAssignComponentToPlatform(versionsProps.get(), component));
+                .all(component -> tryAssignComponentToPlatform(versionsProps, component));
 
         // Gradle 5.1 has a bug whereby a platform dependency whose version comes from a separate constraint end
         // up as two separate entries in the resulting POM, making it invalid.
@@ -193,12 +188,12 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         constraints.forEach(conf.getDependencyConstraints()::add);
     }
 
-    private static Optional<VersionsProps> computeVersionsProps(Path versionsPropsFile) {
+    private static VersionsProps loadVersionsProps(Path versionsPropsFile) {
         if (!Files.exists(versionsPropsFile)) {
-            return Optional.empty();
+            return VersionsProps.empty();
         }
         log.info("Configuring constraints from properties file {}", versionsPropsFile);
-        return Optional.of(new VersionsProps(versionsPropsFile));
+        return VersionsProps.loadFromFile(versionsPropsFile);
     }
 
     private static void checkPreconditions(Project project) {

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -203,6 +203,20 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
         e.output.contains("Not allowed to resolve")
     }
 
+    def "creates rootConfiguration even if versions props file missing"() {
+        buildFile << """
+            dependencies {
+                constraints {
+                    rootConfiguration 'org.slf4j:slf4j-api:1.7.25'
+                }
+            }
+        """.stripIndent()
+        file('versions.props').delete()
+
+        expect:
+        runTasks()
+    }
+
     /**
      * Recursively converts a node's children to a map of <tt>(tag name): (value inside tag)</tt>.
      * <p>

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -202,7 +202,8 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
         def e = runTasksAndFail()
         e.output.contains("Not allowed to resolve")
     }
-/**
+
+    /**
      * Recursively converts a node's children to a map of <tt>(tag name): (value inside tag)</tt>.
      * <p>
      * See: https://stackoverflow.com/a/26889997/274699


### PR DESCRIPTION
## Before this PR

If `versions.props` was missing, VersionsPropsPlugin exited early and didn't do any of the other logic that scripts might expect, such as creating the `rootConfiguration` configuration, and adding hooks to fix platform imports in published boms.

## After this PR

It now treats a missing `versions.props` as if it was empty, and still performs all of the logic the plugin would usually perform.