### PR TITLE
[fix] Allow dependency insight even if there are unresolvable dependencies

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -186,7 +186,14 @@ public class VersionsLockPlugin implements Plugin<Project> {
             }
 
             // Ensure that we throw if there are dependencies that are not present in the lock state.
+            // Unless... dependencies / dependencyInsight was run on the root project
+            ImmutableList<String> tasks = ImmutableList.of(":dependencyInsight", ":dependencies");
             unifiedClasspath.getIncoming().afterResolve(r -> {
+                if (tasks.stream().anyMatch(project.getGradle().getTaskGraph()::hasTask)) {
+                    log.lifecycle("Not checking validity of locks since we are running tasks that inspect "
+                            + "dependencies");
+                    return;
+                }
                 failIfAnyDependenciesUnresolved(r);
 
                 LockState currentLockState = LockStates.toLockState(fullLockStateSupplier.get());


### PR DESCRIPTION
## Before this PR

You couldn't run `dependencyInsight` or `dependencies` on the root `unifiedClasspath`  configuration if it contained unresolvable dependencies.

## After this PR

You can now run these tasks to inspect why you are stuck with an unresolvable configuration for all your dependencies.

Fixes #34

cc @rshkv 