### PR TITLE
Test that virtual platform is applied across projects

### DIFF
--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -25,6 +25,10 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
                 "ch.qos.logback:logback-classic:1.1.11 -> org.slf4j:slf4j-api:1.7.22",
                 "org.slf4j:slf4j-api:1.7.22",
                 "org.slf4j:slf4j-api:1.7.25",
+                "org:a:1.0",
+                "org:a:1.1",
+                "org:b:1.0",
+                "org:b:1.1",
         )
         buildFile << """
             buildscript {
@@ -108,5 +112,37 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         expect:
         runTasks('demo', '--write-locks').output.contains("demo=1.7.25")
+    }
+
+    def "virtual platform is respected across projects"() {
+        addSubproject('foo', """
+            apply plugin: 'java'
+            dependencies {
+                compile 'org:a:1.0'
+            }
+        """.stripIndent())
+
+        addSubproject('bar', """
+            apply plugin: 'java'
+            dependencies {
+                compile 'org:b:1.1'
+            }
+        """.stripIndent())
+
+        file('versions.props') << """
+            # Just to create a platform around org:*
+            org:* = 1.0
+        """.stripIndent()
+
+        when:
+        runTasks('--write-locks')
+
+        then:
+        def expectedLock = """\
+            # Run ./gradlew --write-locks to regenerate this file
+            org:a:1.1 (1 constraints: a5041a2c)
+            org:b:1.1 (1 constraints: a6041b2c)
+        """.stripIndent()
+        file('versions.lock').text == expectedLock
     }
 }

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -25,10 +25,9 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
                 "ch.qos.logback:logback-classic:1.1.11 -> org.slf4j:slf4j-api:1.7.22",
                 "org.slf4j:slf4j-api:1.7.22",
                 "org.slf4j:slf4j-api:1.7.25",
-                "org:a:1.0",
-                "org:a:1.1",
-                "org:b:1.0",
-                "org:b:1.1",
+                "test-alignment:module-that-should-be-aligned-up:1.0",
+                "test-alignment:module-that-should-be-aligned-up:1.1",
+                "test-alignment:module-with-higher-version:1.1",
         )
         buildFile << """
             buildscript {
@@ -118,20 +117,20 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         addSubproject('foo', """
             apply plugin: 'java'
             dependencies {
-                compile 'org:a:1.0'
+                compile 'test-alignment:module-that-should-be-aligned-up:1.0'
             }
         """.stripIndent())
 
         addSubproject('bar', """
             apply plugin: 'java'
             dependencies {
-                compile 'org:b:1.1'
+                compile 'test-alignment:module-with-higher-version:1.1'
             }
         """.stripIndent())
 
         file('versions.props') << """
-            # Just to create a platform around org:*
-            org:* = 1.0
+            # Just to create a platform around test-alignment:*
+            test-alignment:* = 1.0
         """.stripIndent()
 
         when:
@@ -140,8 +139,8 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         then:
         def expectedLock = """\
             # Run ./gradlew --write-locks to regenerate this file
-            org:a:1.1 (1 constraints: a5041a2c)
-            org:b:1.1 (1 constraints: a6041b2c)
+            test-alignment:module-that-should-be-aligned-up:1.1 (1 constraints: a5041a2c)
+            test-alignment:module-with-higher-version:1.1 (1 constraints: a6041b2c)
         """.stripIndent()
         file('versions.lock').text == expectedLock
     }


### PR DESCRIPTION
Add a test that ensures a virtual platform from `versions.props` aligns components coming from different projects.

