### PR TITLE
[improvement] Fail the build if `versions.lock` is missing

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -179,10 +179,14 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 unifiedClasspath.getIncoming().getResolutionResult().getRoot();
             });
         } else {
-            if (Files.notExists(rootLockfile)) {
-                log.warn("Root lock file '{}' doesn't exist, please run "
-                        + "`./gradlew --write-locks` to initialise locks", rootLockfile);
+            if (project.hasProperty("ignoreLockFile")) {
+                log.lifecycle("Ignoring lock file for debugging, because the 'ignoreLockFile' property was set");
                 return;
+            }
+
+            if (Files.notExists(rootLockfile)) {
+                throw new GradleException(String.format("Root lock file '%s' doesn't exist, please run "
+                        + "`./gradlew --write-locks` to initialise locks", rootLockfile));
             }
 
             // Ensure that we throw if there are dependencies that are not present in the lock state.

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -89,6 +89,9 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
             }
         '''.stripIndent()
 
+        // Pretend we have a lock file
+        file('versions.lock') << ''
+
         file('versions.props') << 'org.slf4j:* = 1.7.25'
 
         expect:

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockProjectSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockProjectSpec.groovy
@@ -24,17 +24,10 @@ class VersionsLockProjectSpec extends ProjectSpec {
         return "com.palantir.consistent-versions"
     }
 
-    def 'apply does not throw exceptions'() {
-        when:
-        project.apply plugin: pluginName
+    def 'apply does not throw exceptions if versions.lock exists'() {
+        new File(projectDir, 'versions.lock') << ''
 
-        then:
-        noExceptionThrown()
-    }
-
-    def 'apply is idempotent'() {
         when:
-        project.apply plugin: pluginName
         project.apply plugin: pluginName
 
         then:


### PR DESCRIPTION
## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
The plugin would tolerate a missing `versions.lock` with a warning.

## After this PR
It now fails when `versions.lock` is missing.

It's still possible to allow the build to ignore the lock file by running `./gradlew -PignoreLockFile`, which is only intended for debugging purposes.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->