### PR TITLE
Actually support getVersion with 3 args

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
@@ -64,6 +64,10 @@ public final class GetVersionPlugin implements Plugin<Project> {
                         .getConfigurations()
                         .getByName(VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME));
             }
+
+            public String doCall(String group, String name, Configuration configuration) {
+                return getVersion(project, group, name, configuration);
+            }
         });
     }
 

--- a/src/test/groovy/com/palantir/gradle/versions/GetVersionPluginSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/GetVersionPluginSpec.groovy
@@ -51,6 +51,18 @@ class GetVersionPluginSpec extends ProjectSpec {
         ex.message.contains "Unable to find 'com.google.guava:guava' in configuration ':compile'"
     }
 
+    def 'function is callable from groovy with two string args & configuration arg'() {
+        when:
+        project.apply plugin: GetVersionPlugin
+        project.apply plugin: JavaPlugin
+        project.ext.getVersion('com.google.guava', 'guava', project.configurations.compile)
+
+        then:
+        def ex = thrown(GradleException)
+        ex.message.contains "Unable to find 'com.google.guava:guava' in configuration ':compile'"
+    }
+
+
     def 'function is callable from groovy with two string args'() {
         when:
         project.apply plugin: GetVersionPlugin


### PR DESCRIPTION
## Before this PR

Despite the [readme](https://github.com/palantir/gradle-consistent-versions#getversion) saying you can call `getVersion(group, name, configuration)`, you can't.

## After this PR

==COMMIT_MSG==
Can call `getVersion(group, name, configuration)`.
==COMMIT_MSG==