### PR TITLE
[improvement] Make "dependents changed" error more readable

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -233,21 +233,19 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
         Map<MyModuleIdentifier, ValueDifference<Line>> differing = difference.entriesDiffering();
         if (!differing.isEmpty()) {
-            throw new RuntimeException(
-                    "Found dependencies whose dependents changed: " + formatDependencyDifferences(differing) + ". "
-                            + "Please run './gradlew --write-locks'.");
+            throw new RuntimeException("Found dependencies whose dependents changed:\n"
+                    + formatDependencyDifferences(differing) + "\n\n"
+                    + "Please run './gradlew --write-locks'.");
         }
     }
 
     private static String formatDependencyDifferences(
             Map<MyModuleIdentifier, ValueDifference<Line>> differing) {
         return differing.entrySet().stream().map(diff -> String.format("" // to align strings
-                        + "%s:\n"
-                        + "-   %s\n"
-                        + "+   %s",
-                diff.getKey(),
-                diff.getValue().leftValue(),
-                diff.getValue().rightValue())).collect(Collectors.joining("\n"));
+                        + "-%s\n"
+                        + "+%s",
+                diff.getValue().leftValue().stringRepresentation(),
+                diff.getValue().rightValue().stringRepresentation())).collect(Collectors.joining("\n"));
     }
 
     private static void sourceDependenciesFromProject(

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -234,9 +234,20 @@ public class VersionsLockPlugin implements Plugin<Project> {
         Map<MyModuleIdentifier, ValueDifference<Line>> differing = difference.entriesDiffering();
         if (!differing.isEmpty()) {
             throw new RuntimeException(
-                    "Found dependencies whose dependents changed: " + differing + ". "
+                    "Found dependencies whose dependents changed: " + formatDependencyDifferences(differing) + ". "
                             + "Please run './gradlew --write-locks'.");
         }
+    }
+
+    private static String formatDependencyDifferences(
+            Map<MyModuleIdentifier, ValueDifference<Line>> differing) {
+        return differing.entrySet().stream().map(diff -> String.format("" // to align strings
+                        + "%s:\n"
+                        + "-   %s\n"
+                        + "+   %s",
+                diff.getKey(),
+                diff.getValue().leftValue(),
+                diff.getValue().rightValue())).collect(Collectors.joining("\n"));
     }
 
     private static void sourceDependenciesFromProject(


### PR DESCRIPTION
## Before this PR

The "Found dependencies whose dependents changed" error would dump all of the changed dependents information into one line, which is hard to read.

## After this PR
==COMMIT_MSG==
Make "Found dependencies whose dependents changed" error more readable

It now prints a diff-style output of previous/new value in the lock file format, which is easy for humans to parse.
==COMMIT_MSG==

## Possible downsides?
none