### PR TITLE
[fix] Fix inconsistency of dependents for some direct dependencies

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -158,7 +158,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                 versionsProps
                         .getRecommendedVersion(moduleDependency.getModule())
                         .ifPresent(version -> moduleDependency.version(constraint -> {
-                            log.debug("Found direct dependency without version: {} -> {}, requiring: {}",
+                            log.info("Found direct dependency without version: {} -> {}, requiring: {}",
                                     conf, moduleDependency, version);
                             constraint.require(version);
                         }));

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -158,9 +158,9 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                 versionsProps
                         .getRecommendedVersion(moduleDependency.getModule())
                         .ifPresent(version -> moduleDependency.version(constraint -> {
-                            log.debug("Found direct dependency without version: {} -> {}, preferring: {}",
+                            log.debug("Found direct dependency without version: {} -> {}, requiring: {}",
                                     conf, moduleDependency, version);
-                            constraint.prefer(version);
+                            constraint.require(version);
                         }));
             });
         });


### PR DESCRIPTION
## Before this PR

It's possible that before resolving locks, subproject configurations might have their `withDependencies` actions called. This causes constraints for direct dependencies whose versions are determined via a `*`-glob in `versions.props` to change.
The gradle kotlin plugin has been observed to do this, for instance.

Background:
As part of how `*`-matchers from `versions.props` work, we inject versions via the `withDependencies` hook of a configuration, when we discover direct dependencies in that configuration that do not have a version but that do match a `*` glob from `versions.props`.

We currently inject these as a `preferred` version constraint. However, if these withDependencies actions on a subproject configuration run *before* the `subprojectUnifiedClasspath` of that subproject is resolved, then we get a different type of constraint - it changes what kind of constraint gets resoved from `unifiedClasspath`'s point of view (the top level configuration that contains what versions & constraints we will lock to `versions.lock`).

## After this PR
We now use a *required* version constraint (the default kind) rather than preferred, when injecting versions coming from a `*`-glob. This should make the final lock file agnostic to whether a random `Configuration.getIncoming().getDependencies()` gets called at configuration-time or not.

==COMMIT_MSG==
Fix inconsistency of constraints for direct dependencies whose versions are determined via a `*`-glob in `versions.props`.
==COMMIT_MSG==

## Possible downsides?
This will make lock files change without any other changes, but should be consistent going forward.