### PR TITLE
[fix] Resolve lock state the same whether writing locks or not

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -153,7 +153,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
         // Recursively copy all project configurations that are depended on.
         unifiedClasspath.withDependencies(depSet -> {
             Map<Configuration, String> copiedConfigurationsCache = new HashMap<>();
-            resolveDependentPublications(project, depSet, copiedConfigurationsCache);
+            recursivelyCopyProjectDependencies(project, depSet, copiedConfigurationsCache);
         });
 
         if (project.getGradle().getStartParameter().isWriteDependencyLocks()) {
@@ -333,11 +333,11 @@ public class VersionsLockPlugin implements Plugin<Project> {
     /**
      * Recursive method that copies unseen {@link ProjectDependency project dependencies} found in the given {@link
      * DependencySet}, and then amends their {@link ProjectDependency#getTargetConfiguration()} to point to the copied
-     * configuration. It then configures any copied  recursively through {@link Configuration#withDependencies} which is
-     * lazy, so recursive calls don't actually execute right away, but are executed when those configurations are
-     * evaluated.
+     * configuration. It then configures any copied Configurations recursively through
+     * {@link Configuration#withDependencies} which is lazy, so recursive calls don't actually execute right away,
+     * but are executed when those configurations are evaluated.
      */
-    private void resolveDependentPublications(
+    private void recursivelyCopyProjectDependencies(
             Project currentProject, DependencySet dependencySet, Map<Configuration, String> copiedConfigurationsCache) {
         dependencySet
                 .matching(dependency -> ProjectDependency.class.isAssignableFrom(dependency.getClass()))
@@ -389,7 +389,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
                     projectDep.getConfigurations().add(copiedConf);
 
                     projectDependency.setTargetConfiguration(copiedConf.getName());
-                    resolveDependentPublications(projectDep, copiedConf.getDependencies(), copiedConfigurationsCache);
+                    recursivelyCopyProjectDependencies(projectDep, copiedConf.getDependencies(), copiedConfigurationsCache);
                 });
     }
 

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -136,27 +136,27 @@ public class VersionsLockPlugin implements Plugin<Project> {
         // See: https://github.com/gradle/gradle/pull/7967
         project.getPluginManager().apply("java-base");
 
+        // Gradle will break if you try to add constraints to any configurations that have been resolved.
+        // Since unifiedClasspath depends on the SUBPROJECT_UNIFIED_CONFIGURATION_NAME configuration of all
+        // subprojects (above), that would resolve them when we resolve unifiedClasspath. We need this workaround
+        // to enable the workflow:
+        //
+        //  1. when 'unifiedClasspath' is resolved with --write-locks, it writes the lock file and resolves its
+        //     dependencies
+        //  2. read the lock file
+        //  3. enforce these versions on all subprojects, using constraints
+        //
+        // Since we can't apply these constraints to the already resolved configurations, we need a workaround to
+        // ensure that unifiedClasspath does not directly depend on subproject configurations that we intend to
+        // enforce constraints on.
+
+        // Recursively copy all project configurations that are depended on.
+        unifiedClasspath.withDependencies(depSet -> {
+            Map<Configuration, String> copiedConfigurationsCache = new HashMap<>();
+            resolveDependentPublications(project, depSet, copiedConfigurationsCache);
+        });
+
         if (project.getGradle().getStartParameter().isWriteDependencyLocks()) {
-            // Gradle will break if you try to add constraints to any configurations that have been resolved.
-            // Since unifiedClasspath depends on the SUBPROJECT_UNIFIED_CONFIGURATION_NAME configuration of all
-            // subprojects (above), that would resolve them when we resolve unifiedClasspath. We need this workaround
-            // to enable the workflow:
-            //
-            //  1. when 'unifiedClasspath' is resolved with --write-locks, it writes the lock file and resolves its
-            //     dependencies
-            //  2. read the lock file
-            //  3. enforce these versions on all subprojects, using constraints
-            //
-            // Since we can't apply these constraints to the already resolved configurations, we need a workaround to
-            // ensure that unifiedClasspath does not directly depend on subproject configurations that we intend to
-            // enforce constraints on.
-
-            // Recursively copy all project configurations that are depended on.
-            unifiedClasspath.withDependencies(depSet -> {
-                Map<Configuration, String> copiedConfigurationsCache = new HashMap<>();
-                resolveDependentPublications(project, depSet, copiedConfigurationsCache);
-            });
-
             // Must wire up the constraint configuration to right AFTER rootProject has written theirs
             unifiedClasspath.getIncoming().afterResolve(r -> {
                 failIfAnyDependenciesUnresolved(r);

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -389,7 +389,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
                     projectDep.getConfigurations().add(copiedConf);
 
                     projectDependency.setTargetConfiguration(copiedConf.getName());
-                    recursivelyCopyProjectDependencies(projectDep, copiedConf.getDependencies(), copiedConfigurationsCache);
+                    recursivelyCopyProjectDependencies(
+                            projectDep, copiedConf.getDependencies(), copiedConfigurationsCache);
                 });
     }
 


### PR DESCRIPTION
## Before this PR

When running with `--write-locks`, we transitively copy all dependencies of `unifiedClasspath` through project dependencies, and then resolve this copied graph. This is so we don't force the actual java configurations in subprojects, so that we can still apply the locked constraints afterwards.

When running without, however, we don't do the above, and just resolve `unifiedClasspath` directly, in order to determine the "current lock state".
But this means that existing constraints from the lock file would feed back into the current lock state, which might cause it to be different from what you'd get if you ran with `--write-locks`.

## After this PR
==COMMIT_MSG==
Resolve the lock state in the same way whether running with `--write-locks` or not, to make sure they are consistent.
==COMMIT_MSG==

## Possible downsides?
* If the resolution we do now (via transitively copying configurations) is broken, for instance if it ends up missing dependencies we are actually using, then we end up just not locking those dependencies, and we wouldn't know about it.