### PR TITLE
[improvement] Move lock verification to a task that check depends on

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
+++ b/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
@@ -1,0 +1,93 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions;
+
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.MapDifference.ValueDifference;
+import com.google.common.collect.Maps;
+import com.palantir.gradle.versions.internal.MyModuleIdentifier;
+import com.palantir.gradle.versions.lockstate.Line;
+import com.palantir.gradle.versions.lockstate.LockState;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.TaskAction;
+
+public class VerifyLocksTask extends DefaultTask {
+
+    private final Property<LockState> persistedLockState;
+    private final Property<LockState> currentLockState;
+
+    public VerifyLocksTask() {
+        this.persistedLockState = getProject().getObjects().property(LockState.class);
+        this.currentLockState = getProject().getObjects().property(LockState.class);
+
+        setGroup("verification");
+        setDescription("Verifies that your versions.lock is consistent with current dependencies");
+    }
+
+    public final void persistedLockState(Provider<LockState> provider) {
+        this.persistedLockState.set(provider);
+    }
+
+    public final void currentLockState(Provider<LockState> provider) {
+        this.currentLockState.set(provider);
+    }
+
+    @TaskAction
+    public final void taskAction() {
+        ensureLockStateIsUpToDate(currentLockState.get(), persistedLockState.get());
+    }
+
+    private static void ensureLockStateIsUpToDate(LockState currentLockState, LockState persistedLockState) {
+        MapDifference<MyModuleIdentifier, Line> difference = Maps.difference(
+                persistedLockState.linesByModuleIdentifier(), currentLockState.linesByModuleIdentifier());
+
+        Set<MyModuleIdentifier> missing = difference.entriesOnlyOnLeft().keySet();
+        if (!missing.isEmpty()) {
+            throw new RuntimeException(
+                    "Locked dependencies missing from the resolution result: " + missing + ". "
+                            + ". Please run './gradlew --write-locks'.");
+        }
+
+        Set<MyModuleIdentifier> unknown = difference.entriesOnlyOnRight().keySet();
+        if (!unknown.isEmpty()) {
+            throw new RuntimeException(
+                    "Found dependencies that were not in the lock state: " + unknown + ". "
+                            + "Please run './gradlew --write-locks'.");
+        }
+
+        Map<MyModuleIdentifier, ValueDifference<Line>> differing = difference.entriesDiffering();
+        if (!differing.isEmpty()) {
+            throw new RuntimeException("Found dependencies whose dependents changed:\n"
+                    + formatDependencyDifferences(differing) + "\n\n"
+                    + "Please run './gradlew --write-locks'.");
+        }
+    }
+
+    private static String formatDependencyDifferences(
+            Map<MyModuleIdentifier, ValueDifference<Line>> differing) {
+        return differing.entrySet().stream().map(diff -> String.format("" // to align strings
+                        + "-%s\n"
+                        + "+%s",
+                diff.getValue().leftValue().stringRepresentation(),
+                diff.getValue().rightValue().stringRepresentation())).collect(Collectors.joining("\n"));
+    }
+}

--- a/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
+++ b/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
@@ -44,22 +44,20 @@ public class VerifyLocksTask extends DefaultTask {
         setDescription("Verifies that your versions.lock is up to date");
     }
 
-    public final void persistedLockState(Provider<LockState> provider) {
-        this.persistedLockState.set(provider);
+    @Input
+    final Property<LockState> getPersistedLockState() {
+        return persistedLockState;
     }
 
-    public final void currentLockState(Provider<LockState> provider) {
-        this.currentLockState.set(provider);
+    @Input
+    final Property<LockState> getCurrentLockState() {
+        return currentLockState;
     }
 
     @TaskAction
     public final void taskAction() {
-        ensureLockStateIsUpToDate(currentLockState.get(), persistedLockState.get());
-    }
-
-    private static void ensureLockStateIsUpToDate(LockState currentLockState, LockState persistedLockState) {
         MapDifference<MyModuleIdentifier, Line> difference = Maps.difference(
-                persistedLockState.linesByModuleIdentifier(), currentLockState.linesByModuleIdentifier());
+                persistedLockState.get().linesByModuleIdentifier(), currentLockState.get().linesByModuleIdentifier());
 
         Set<MyModuleIdentifier> missing = difference.entriesOnlyOnLeft().keySet();
         if (!missing.isEmpty()) {

--- a/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
+++ b/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
@@ -41,7 +41,7 @@ public class VerifyLocksTask extends DefaultTask {
         this.currentLockState = getProject().getObjects().property(LockState.class);
 
         setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
-        setDescription("Verifies that your versions.lock is consistent with current dependencies");
+        setDescription("Verifies that your versions.lock is up to date");
     }
 
     public final void persistedLockState(Provider<LockState> provider) {

--- a/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
+++ b/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
@@ -29,6 +29,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
 public class VerifyLocksTask extends DefaultTask {
 
@@ -39,7 +40,7 @@ public class VerifyLocksTask extends DefaultTask {
         this.persistedLockState = getProject().getObjects().property(LockState.class);
         this.currentLockState = getProject().getObjects().property(LockState.class);
 
-        setGroup("verification");
+        setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
         setDescription("Verifies that your versions.lock is consistent with current dependencies");
     }
 

--- a/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
+++ b/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
@@ -42,12 +42,12 @@ public class VerifyLocksTask extends DefaultTask {
     private final Property<LockState> currentLockState;
 
     public VerifyLocksTask() {
+        setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
+        setDescription("Verifies that your versions.lock is up to date");
+
         this.outputFile = new File(getTemporaryDir(), "verified");
         this.persistedLockState = getProject().getObjects().property(LockState.class);
         this.currentLockState = getProject().getObjects().property(LockState.class);
-
-        setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
-        setDescription("Verifies that your versions.lock is up to date");
     }
 
     @Input

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -195,13 +195,12 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 failIfAnyDependenciesUnresolved(r);
             });
 
-            TaskProvider<VerifyLocksTask> verifyLocks =
-                    project.getTasks().register("verifyLocks", VerifyLocksTask.class, task -> {
-                        task.currentLockState(
-                                project.provider(() -> LockStates.toLockState(fullLockStateSupplier.get())));
-                        task.persistedLockState(
-                                project.provider(() -> new ConflictSafeLockFile(rootLockfile).readLocks()));
-                    });
+            TaskProvider verifyLocks = project.getTasks().register("verifyLocks", VerifyLocksTask.class, task -> {
+                task.currentLockState(
+                        project.provider(() -> LockStates.toLockState(fullLockStateSupplier.get())));
+                task.persistedLockState(
+                        project.provider(() -> new ConflictSafeLockFile(rootLockfile).readLocks()));
+            });
 
             project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(check -> {
                 check.dependsOn(verifyLocks);

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -132,27 +132,27 @@ public class VersionsLockPlugin implements Plugin<Project> {
         // See: https://github.com/gradle/gradle/pull/7967
         project.getPluginManager().apply("java-base");
 
-        // Gradle will break if you try to add constraints to any configurations that have been resolved.
-        // Since unifiedClasspath depends on the SUBPROJECT_UNIFIED_CONFIGURATION_NAME configuration of all
-        // subprojects (above), that would resolve them when we resolve unifiedClasspath. We need this workaround
-        // to enable the workflow:
-        //
-        //  1. when 'unifiedClasspath' is resolved with --write-locks, it writes the lock file and resolves its
-        //     dependencies
-        //  2. read the lock file
-        //  3. enforce these versions on all subprojects, using constraints
-        //
-        // Since we can't apply these constraints to the already resolved configurations, we need a workaround to
-        // ensure that unifiedClasspath does not directly depend on subproject configurations that we intend to
-        // enforce constraints on.
-
-        // Recursively copy all project configurations that are depended on.
-        unifiedClasspath.withDependencies(depSet -> {
-            Map<Configuration, String> copiedConfigurationsCache = new HashMap<>();
-            resolveDependentPublications(project, depSet, copiedConfigurationsCache);
-        });
-
         if (project.getGradle().getStartParameter().isWriteDependencyLocks()) {
+            // Gradle will break if you try to add constraints to any configurations that have been resolved.
+            // Since unifiedClasspath depends on the SUBPROJECT_UNIFIED_CONFIGURATION_NAME configuration of all
+            // subprojects (above), that would resolve them when we resolve unifiedClasspath. We need this workaround
+            // to enable the workflow:
+            //
+            //  1. when 'unifiedClasspath' is resolved with --write-locks, it writes the lock file and resolves its
+            //     dependencies
+            //  2. read the lock file
+            //  3. enforce these versions on all subprojects, using constraints
+            //
+            // Since we can't apply these constraints to the already resolved configurations, we need a workaround to
+            // ensure that unifiedClasspath does not directly depend on subproject configurations that we intend to
+            // enforce constraints on.
+
+            // Recursively copy all project configurations that are depended on.
+            unifiedClasspath.withDependencies(depSet -> {
+                Map<Configuration, String> copiedConfigurationsCache = new HashMap<>();
+                resolveDependentPublications(project, depSet, copiedConfigurationsCache);
+            });
+
             // Must wire up the constraint configuration to right AFTER rootProject has written theirs
             unifiedClasspath.getIncoming().afterResolve(r -> {
                 failIfAnyDependenciesUnresolved(r);

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -136,27 +136,27 @@ public class VersionsLockPlugin implements Plugin<Project> {
         // See: https://github.com/gradle/gradle/pull/7967
         project.getPluginManager().apply("java-base");
 
+        // Gradle will break if you try to add constraints to any configurations that have been resolved.
+        // Since unifiedClasspath depends on the SUBPROJECT_UNIFIED_CONFIGURATION_NAME configuration of all
+        // subprojects (above), that would resolve them when we resolve unifiedClasspath. We need this workaround
+        // to enable the workflow:
+        //
+        //  1. when 'unifiedClasspath' is resolved with --write-locks, it writes the lock file and resolves its
+        //     dependencies
+        //  2. read the lock file
+        //  3. enforce these versions on all subprojects, using constraints
+        //
+        // Since we can't apply these constraints to the already resolved configurations, we need a workaround to
+        // ensure that unifiedClasspath does not directly depend on subproject configurations that we intend to
+        // enforce constraints on.
+
+        // Recursively copy all project configurations that are depended on.
+        unifiedClasspath.withDependencies(depSet -> {
+            Map<Configuration, String> copiedConfigurationsCache = new HashMap<>();
+            resolveDependentPublications(project, depSet, copiedConfigurationsCache);
+        });
+
         if (project.getGradle().getStartParameter().isWriteDependencyLocks()) {
-            // Gradle will break if you try to add constraints to any configurations that have been resolved.
-            // Since unifiedClasspath depends on the SUBPROJECT_UNIFIED_CONFIGURATION_NAME configuration of all
-            // subprojects (above), that would resolve them when we resolve unifiedClasspath. We need this workaround
-            // to enable the workflow:
-            //
-            //  1. when 'unifiedClasspath' is resolved with --write-locks, it writes the lock file and resolves its
-            //     dependencies
-            //  2. read the lock file
-            //  3. enforce these versions on all subprojects, using constraints
-            //
-            // Since we can't apply these constraints to the already resolved configurations, we need a workaround to
-            // ensure that unifiedClasspath does not directly depend on subproject configurations that we intend to
-            // enforce constraints on.
-
-            // Recursively copy all project configurations that are depended on.
-            unifiedClasspath.withDependencies(depSet -> {
-                Map<Configuration, String> copiedConfigurationsCache = new HashMap<>();
-                resolveDependentPublications(project, depSet, copiedConfigurationsCache);
-            });
-
             // Must wire up the constraint configuration to right AFTER rootProject has written theirs
             unifiedClasspath.getIncoming().afterResolve(r -> {
                 failIfAnyDependenciesUnresolved(r);

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -196,10 +196,12 @@ public class VersionsLockPlugin implements Plugin<Project> {
             });
 
             TaskProvider verifyLocks = project.getTasks().register("verifyLocks", VerifyLocksTask.class, task -> {
-                task.currentLockState(
-                        project.provider(() -> LockStates.toLockState(fullLockStateSupplier.get())));
-                task.persistedLockState(
-                        project.provider(() -> new ConflictSafeLockFile(rootLockfile).readLocks()));
+                task
+                        .getCurrentLockState()
+                        .set(project.provider(() -> LockStates.toLockState(fullLockStateSupplier.get())));
+                task
+                        .getPersistedLockState()
+                        .set(project.provider(() -> new ConflictSafeLockFile(rootLockfile).readLocks()));
             });
 
             project.getTasks().named(LifecycleBasePlugin.CHECK_TASK_NAME).configure(check -> {

--- a/src/main/java/com/palantir/gradle/versions/lockstate/Line.java
+++ b/src/main/java/com/palantir/gradle/versions/lockstate/Line.java
@@ -17,12 +17,13 @@
 package com.palantir.gradle.versions.lockstate;
 
 import com.palantir.gradle.versions.internal.MyModuleIdentifier;
+import java.io.Serializable;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Lazy;
 import org.immutables.value.Value.Parameter;
 
 @Value.Immutable
-public interface Line {
+public interface Line extends Serializable {
     @Parameter
     String group();
 

--- a/src/main/java/com/palantir/gradle/versions/lockstate/LockState.java
+++ b/src/main/java/com/palantir/gradle/versions/lockstate/LockState.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.versions.lockstate;
 import com.google.common.collect.ImmutableSortedMap;
 import com.palantir.gradle.versions.GradleComparators;
 import com.palantir.gradle.versions.internal.MyModuleIdentifier;
+import java.io.Serializable;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.function.Function;
@@ -31,7 +32,7 @@ import org.immutables.value.Value.Parameter;
  * Holds the state of dependencies that should be written to disk when gradle is invoked with {@code --write-locks}.
  */
 @Value.Immutable
-public interface LockState {
+public interface LockState extends Serializable {
 
     @Parameter
     List<Line> lines();

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -329,9 +329,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         runTasks('verifyLocks')
     }
 
-    def 'does not fail if unifiedClasspath is unresolvable but we are running dependencies'() {
-        def notCheckingLocksMessage = "Not checking validity of locks"
-
+    def 'does not fail if unifiedClasspath is unresolvable'() {
         file('versions.lock') << """\
             org.slf4j:slf4j-api:1.7.11 (0 constraints: 0000000)
         """.stripIndent()
@@ -344,12 +342,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         '''.stripIndent())
 
         expect:
-        def result = runTasks('dependencies', '--configuration', 'unifiedClasspath')
-        result.output.contains(notCheckingLocksMessage)
-
-        // Fails if we don't run dependencies
-        def failure = runTasksAndFail(':resolveConfigurations')
-        !failure.output.contains(notCheckingLocksMessage)
+        runTasks('dependencies', '--configuration', 'unifiedClasspath')
     }
 
     def 'fails if dependency was removed but still in the lock file'() {

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -57,7 +57,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
     def 'can write locks'() {
         expect:
-        runTasks('resolveConfigurations', '--write-locks')
+        runTasks('--write-locks')
         new File(projectDir, "versions.lock").exists()
     }
 
@@ -248,7 +248,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         standardSetup()
 
         when: "I write locks"
-        runTasks('resolveConfigurations', '--write-locks')
+        runTasks('--write-locks')
 
         then: "Root lock file has expected resolution result"
         file("versions.lock").text.readLines().any { it.contains('org.slf4j:slf4j-api:1.7.24') }

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -319,13 +319,14 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
             }
         """.stripIndent()
 
-        then: 'Check should depend on verifyLocks'
+        then: 'Check fails because locks are not up to date'
         def failure = runTasksAndFail(':check')
         failure.task(':verifyLocks').outcome == TaskOutcome.FAILED
         failure.output.contains(expectedError)
 
         and: 'Can finally write locks once again'
         runTasks('--write-locks')
+        runTasks('verifyLocks')
     }
 
     def 'does not fail if unifiedClasspath is unresolvable but we are running dependencies'() {
@@ -383,13 +384,14 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
             }
         """.stripIndent()
 
-        then: 'Check should depend on verifyLocks'
+        then: 'Check fails because locks are not up to date'
         def failure = runTasksAndFail(':check')
         failure.task(':verifyLocks').outcome == TaskOutcome.FAILED
         failure.output.contains(expectedError)
 
         and: 'Can finally write locks once again'
         runTasks('--write-locks')
+        runTasks('verifyLocks')
     }
 
     def "why works"() {

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -343,6 +343,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         expect:
         runTasks('dependencies', '--configuration', 'unifiedClasspath')
+        runTasks()
     }
 
     def 'fails if dependency was removed but still in the lock file'() {

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -19,6 +19,7 @@ package com.palantir.gradle.versions
 import nebula.test.dependencies.DependencyGraph
 import nebula.test.dependencies.GradleDependencyGenerator
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
 
 class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
@@ -309,7 +310,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
             }
         '''.stripIndent())
 
-        runTasks(':resolveConfigurations', '--write-locks')
+        runTasks('--write-locks')
 
         when:
         file('foo/build.gradle') << """
@@ -318,10 +319,13 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
             }
         """.stripIndent()
 
-        then:
-        def failure = runTasksAndFail(':resolveConfigurations')
+        then: 'Check should depend on verifyLocks'
+        def failure = runTasksAndFail(':check')
+        failure.task(':verifyLocks').outcome == TaskOutcome.FAILED
         failure.output.contains(expectedError)
-        runTasks(':resolveConfigurations', '--write-locks')
+
+        and: 'Can finally write locks once again'
+        runTasks('--write-locks')
     }
 
     def 'does not fail if unifiedClasspath is unresolvable but we are running dependencies'() {
@@ -370,7 +374,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
             }
         '''.stripIndent())
 
-        runTasks(':resolveConfigurations', '--write-locks')
+        runTasks('--write-locks')
 
         when:
         file('foo/build.gradle').text = """
@@ -379,10 +383,13 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
             }
         """.stripIndent()
 
-        then:
-        def failure = runTasksAndFail(':resolveConfigurations')
+        then: 'Check should depend on verifyLocks'
+        def failure = runTasksAndFail(':check')
+        failure.task(':verifyLocks').outcome == TaskOutcome.FAILED
         failure.output.contains(expectedError)
-        runTasks(':resolveConfigurations', '--write-locks')
+
+        and: 'Can finally write locks once again'
+        runTasks('--write-locks')
     }
 
     def "why works"() {


### PR DESCRIPTION
## Before this PR

We only verify that the lock state is still consistent if the user resolves the `unifiedClasspath` task, either intentionally or through a plugin like [palantir/gradle-configuration-resolver-plugin](https://github.com/palantir/gradle-configuration-resolver-plugin), but the latter comes with the downside that it potentially downloads a lot of stuff you don't need, since it resolves all configurations.

On the other hand, resolving just `unifiedClasspath` is a bit annoying, you can't even run `dependencies --configuration unifiedClasspath` because we special cased that to not fail. So the alternative is to create a custom task that resolves unifiedClasspath - not great.

## After this PR
We now have a bespoke task for verifying that locks are still consistent, `verifyLocks`.

==COMMIT_MSG==
Lock verification can now be triggered via the `verifyLocks` task, which the lifecycle `check` task depends on.

WARNING: Locks are no longer verified for consistency as part of resolving unifiedClasspath
==COMMIT_MSG==

## Possible downsides?
* It might be confusing that lock verification now happens at a different point than before. However, it should be a lot more controllable now.