### PR TITLE
[fix] Fix locked versions feeding back into new lock state

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -166,7 +166,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
             }
 
             // projectsEvaluated is necessary to ensure all projects' dependencies have been configured, because we
-            // need to copy them eagerly before we configure constraints.
+            // need to copy them eagerly before we add the constraints from the lock file.
             project.getGradle().projectsEvaluated(g -> {
                 // Recursively copy all project dependencies, so that the constraints we add below won't affect the
                 // resolution of unifiedClasspath.
@@ -446,10 +446,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
     }
 
     private static void configureAllProjectsUsingConstraints(Project rootProject, Path gradleLockfile) {
-        // Construct constraints for all versions locked by root project.
         List<DependencyConstraint> constraints =
-                constructConstraints(gradleLockfile, rootProject.getDependencies().getConstraints());
-
+                constructConstraintsFromLockFile(gradleLockfile, rootProject.getDependencies().getConstraints());
         rootProject.allprojects(subproject -> configureUsingConstraints(subproject, constraints));
     }
 
@@ -483,7 +481,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
     }
 
     @NotNull
-    private static List<DependencyConstraint> constructConstraints(
+    private static List<DependencyConstraint> constructConstraintsFromLockFile(
             Path gradleLockfile, DependencyConstraintHandler constraintHandler) {
         return new ConflictSafeLockFile(gradleLockfile)
                 .readLocks()

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -297,9 +297,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
     /**
      * Recursive method that copies unseen {@link ProjectDependency project dependencies} found in the given {@link
      * DependencySet}, and then amends their {@link ProjectDependency#getTargetConfiguration()} to point to the copied
-     * configuration. It then configures any copied Configurations recursively through
-     * {@link Configuration#withDependencies} which is lazy, so recursive calls don't actually execute right away,
-     * but are executed when those configurations are evaluated.
+     * configuration. It then eagerly configures any copied Configurations recursively.
      */
     private void recursivelyCopyProjectDependencies(
             Project currentProject, DependencySet dependencySet, Map<Configuration, String> copiedConfigurationsCache) {


### PR DESCRIPTION
## Before this PR

Addresses another root cause of https://github.com/palantir/gradle-consistent-versions/issues/117.
Specifically, when deciding the "current" lock state as part of the `verifyLocks` task, current constraints coming from `vesions.lock` are taken into account when doing that resolution.

As an example, a version of `1.2.0` from `versions.lock` will artifically raise the version in the "current lock state", even if the constraints have since changed such that they only require `1.1.0`. In that case, `verifyLocks` would think everything is up to date, even if `--write-locks` would actually produce a different lock file (with the correct new version of `1.1.0`).

## After this PR
==COMMIT_MSG==
Fix locked versions feeding back into new lock state. `verifyLocks` determines current lock state completely independently of the current versions in `versions.lock`.
==COMMIT_MSG==

We also simplified how we configure the recursive dependency copying for unifiedClasspath - instead of relying on the laziness of `withDependencies`, which was hard to follow, we just call the `recursivelyCopyProjectDependencies` method at the appropriate time in each case (writing locks vs not).

## Possible downsides?
