### PR TITLE
Exclude subprojectUnifiedClasspath by name in versions-props

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -91,7 +91,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
     /**
      * Per-project configuration that extends the configurations whose dependencies we are interested in.
      */
-    private static final String SUBPROJECT_UNIFIED_CONFIGURATION_NAME = "subprojectUnifiedClasspath";
+    static final String SUBPROJECT_UNIFIED_CONFIGURATION_NAME = "subprojectUnifiedClasspath";
     /** Configuration to which we apply the constraints from the lock file. */
     private static final String LOCK_CONSTRAINTS_CONFIGURATION_NAME = "lockConstraints";
     private static final Attribute<Boolean> CONSISTENT_VERSIONS_CONSTRAINT_ATTRIBUTE =
@@ -249,9 +249,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
         project.getConfigurations().register(SUBPROJECT_UNIFIED_CONFIGURATION_NAME, conf -> {
             conf.setVisible(false).setCanBeResolved(false);
-
-            // Mark it so it doesn't receive constraints from VersionsPropsPlugin
-            conf.getAttributes().attribute(VersionsPropsPlugin.CONFIGURATION_EXCLUDE_ATTRIBUTE, true);
 
             // Mark it as a GCV_SOURCE, so that it becomes selected (as the best matching configuration) for the
             // user's normal inter-project dependencies

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
 import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
@@ -30,7 +29,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ExternalDependency;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
-import org.gradle.api.attributes.Attribute;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.publish.PublishingExtension;
@@ -41,10 +39,6 @@ public class VersionsPropsPlugin implements Plugin<Project> {
     private static final Logger log = Logging.getLogger(VersionsPropsPlugin.class);
     private static final String ROOT_CONFIGURATION_NAME = "rootConfiguration";
     private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("5.1");
-
-    /** Marks configurations for which we shouldn't inject constraints from {@code versions.props}. */
-    static final Attribute<Boolean> CONFIGURATION_EXCLUDE_ATTRIBUTE =
-            Attribute.of("com.palantir.consistent-versions.exclude-from-versions-props", Boolean.class);
 
     @Override
     public final void apply(Project project) {
@@ -122,7 +116,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         // As an optimization, don't extend some configurations created by VersionsLockPlugin, because
         // it's unnecessary. Note that we still need to apply direct dependency injection on them though,
         // that is intentional.
-        if (Objects.equals(true, conf.getAttributes().getAttribute(CONFIGURATION_EXCLUDE_ATTRIBUTE))) {
+        if (VersionsLockPlugin.SUBPROJECT_UNIFIED_CONFIGURATION_NAME.equals(conf.getName())) {
             return;
         }
 


### PR DESCRIPTION
## Before this PR

Using complicated gradle attributes to coordinate behaviour between two plugins (VersionsLockPlugin and VersionsPropsPlugin).
Specifically, behaviour we want is to not add versions.props constraints to the  `subprojectUnifiedClasspath` configuration created by VersionsLockPlugin.

## After this PR
==COMMIT_MSG==
Make VersionsPropsPlugin directly aware of configurations created by VersionsLockPlugin that it should ignore.
==COMMIT_MSG==

This removes the need for a complicated attribute-based filtering scheme which was on top of the already existing extension-based filtering scheme.

This is a FLUP to https://github.com/palantir/gradle-consistent-versions/pull/134/files#r289342390

## Possible downsides?
