### PR TITLE
Get rid of unnecessary attribute

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -104,8 +104,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
     /** Configuration to which we apply the constraints from the lock file. */
     private static final String LOCK_CONSTRAINTS_CONFIGURATION_NAME = "lockConstraints";
 
-    private static final Attribute<Boolean> CONSISTENT_VERSIONS_CONSTRAINT_ATTRIBUTE =
-            Attribute.of("consistent-versions", Boolean.class);
     private static final String CONSISTENT_VERSIONS_PRODUCTION = "consistentVersionsProduction";
     private static final String CONSISTENT_VERSIONS_TEST = "consistentVersionsTest";
     private static final String VERSIONS_LOCK_EXTENSION = "versionsLock";
@@ -647,7 +645,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
         return Dependents.of(component
                 .getDependents()
                 .stream()
-                .filter(dep -> !dep.getRequested().getAttributes().contains(CONSISTENT_VERSIONS_CONSTRAINT_ATTRIBUTE))
                 .collect(Collectors.groupingBy(
                         dep -> dep.getFrom().getId(),
                         () -> new TreeMap<>(GradleComparators.COMPONENT_IDENTIFIER_COMPARATOR),
@@ -793,10 +790,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 .map(notation -> constraintHandler.create(notation, constraint -> {
                     constraint.version(v -> v.strictly(Objects.requireNonNull(constraint.getVersion())));
                     constraint.because("Locked by versions.lock");
-                    // We set this in order to identify these constraints later.
-                    constraint.attributes(attributeContainer -> {
-                        attributeContainer.attribute(CONSISTENT_VERSIONS_CONSTRAINT_ATTRIBUTE, true);
-                    });
                 }))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## Before this PR
We were excluding constraints that came from the lock file from the lock state computation, but that is now pointless after the fix in https://github.com/palantir/gradle-consistent-versions/pull/125.
This was previously used in order to accomplish (badly) what #125 fixed correctly.

## After this PR
==COMMIT_MSG==
Remove unnecessary filtering of constraints that came from the lock file
==COMMIT_MSG==

## Possible downsides?
