### PR TITLE
[fix] Fail if configure-on-demand

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -372,6 +372,11 @@ public class VersionsLockPlugin implements Plugin<Project> {
             throw new GradleException("Must be applied only to root project");
         }
 
+        Preconditions.checkState(
+                !project.getGradle().getStartParameter().isConfigureOnDemand(),
+                "Gradle Consistent Versions doesn't currently work with configure-on-demand, please remove"
+                        + " 'org.gradle.configureondemand' from your gradle.properties");
+
         project.subprojects(subproject -> {
             subproject.afterEvaluate(sub -> {
                 if (haveSameGroupAndName(project, sub)) {


### PR DESCRIPTION
## Before this PR

After #125, we are using projectsEvaluated which doesn't interact well with configure-on-demand (see [gradle/gradle#9489](https://github.com/gradle/gradle/issues/9489)).
Additionally, the plugin as it is currently written will force-evaluate all subprojects anyway, so there is no point in attempting to use configure-on-demand until GCV stops requiring all projects to be evaluated (blocked on the above gradle issue).

## After this PR
==COMMIT_MSG==
Fail the build if configure-on-demand is enabled.
==COMMIT_MSG==

Fixes #135.

## Possible downsides?
