### PR TITLE
[fix] Prevent placeholder configuration being resolved accidentally

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -535,6 +535,9 @@ public class VersionsLockPlugin implements Plugin<Project> {
                     copiedConf.setCanBeConsumed(true);
                     // But this should never be resolved! (it will most likely fail to given the usage above)
                     copiedConf.setCanBeResolved(false);
+                    // Since we only depend on these from the same project (via CONSISTENT_VERSIONS_PRODUCTION or
+                    // CONSISTENT_VERSIONS_TEST), we shouldn't allow them to be visible outside this project.
+                    copiedConf.setVisible(false);
                     // This is so we can get back the scope from the ResolutionResult.
                     copiedConf
                             .getDependencies()


### PR DESCRIPTION
## Before this PR

When resolving an inter-project dependency from a java configuration (e.g. `compileClasspath`), attribute-based resolution might fail if some detail such as jvm version doesn't match.
In this case, `consistentVersionsPlaceholder` will be selected, as it doesn't declare any attribute that would mismatch the ones required by `compileClasspath` (and gradle allows resolving to such a configuration as a fallback, if no other configurations matched the required attributes).

## After this PR
==COMMIT_MSG==
Prevent GCV internal configurations from being inadvertently selected when resolving java api / runtime if the normal variants (`apiElements` / `runtimeElements`) didn't match some attribute like JVM version.
==COMMIT_MSG==

## Possible downsides?
