### PR TITLE
[fix] Re-allow importing from IntelliJ

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -254,6 +254,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
             // [1]: https://github.com/JetBrains/intellij-community/commit/f394c51cff59c69bbaf63a8bf67cefbad9e357aa#diff-04b9936e4249a0f5727414555b76c4b9R123
             project.afterEvaluate(g -> {
                 // Ensure all other projects have been resolved before.
+                // This is so that plugins that configure subprojects (gradle-conjure) continue to work.
                 project.getSubprojects().forEach(subproject -> project.evaluationDependsOn(subproject.getPath()));
 
                 // Recursively copy all project dependencies, so that the constraints we add below won't affect the

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -246,9 +246,16 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 configureAllProjectsUsingConstraints(project, rootLockfile, lockedConfigurations);
             });
         } else {
-            // projectsEvaluated is necessary to ensure all projects' dependencies have been configured, because we
+            // afterEvaluate is necessary to ensure all projects' dependencies have been configured, because we
             // need to copy them eagerly before we add the constraints from the lock file.
-            project.getGradle().projectsEvaluated(g -> {
+
+            // Note: do not use Gradle.projectsEvaluated here, as IntelliJ's [gradle import action][1] happens BEFORE
+            // that, and will thus resolve the locked configurations before we get a change to add constraints to them.
+            // [1]: https://github.com/JetBrains/intellij-community/commit/f394c51cff59c69bbaf63a8bf67cefbad9e357aa#diff-04b9936e4249a0f5727414555b76c4b9R123
+            project.afterEvaluate(g -> {
+                // Ensure all other projects have been resolved before.
+                project.getSubprojects().forEach(subproject -> project.evaluationDependsOn(subproject.getPath()));
+
                 // Recursively copy all project dependencies, so that the constraints we add below won't affect the
                 // resolution of unifiedClasspath.
                 Map<Project, LockedConfigurations> lockedConfigurations = wireUpLockedConfigurationsByProject(project);


### PR DESCRIPTION
## Before this PR

[1.9.0](https://github.com/palantir/gradle-consistent-versions/releases/tag/1.9.0) introduced a regression via https://github.com/palantir/gradle-consistent-versions/pull/141 whereby we were configuring constraints from the lock file too late.
This interacted badly with the way IntelliJ IDEA imports projects, [the BuildAction it wires up](https://github.com/JetBrains/intellij-community/commit/f394c51cff59c69bbaf63a8bf67cefbad9e357aa#diff-04b9936e4249a0f5727414555b76c4b9R123) seems to run before our `projectsEvaluated` hook, and resolves the configurations that GCV was intending to lock, causing this kind of error upon import:

```
FAILURE: Build failed with an exception.

* What went wrong:
Cannot change dependencies of configuration ':client-config:compileClasspath' after it has been resolved.
```

## After this PR
==COMMIT_MSG==
Fix regression in 1.9.0 which prevented importing projects from inside IntelliJ.
==COMMIT_MSG==

## Possible downsides?
no