### PR TITLE
Mention need to use java-base with BOMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Gradle has [first-class support][bom] for sourcing version constraints from publ
 
 ```gradle
 allprojects {
+    apply plugin: 'java-base'
     dependencies {
         rootConfiguration platform('com.foo.bar:your-bom')
     }
@@ -191,6 +192,8 @@ allprojects {
 [bom]: https://docs.gradle.org/4.6/release-notes.html#bom-import
 
 Make sure you apply BOMs within an `allprojects` closure, as gradle-consistent-versions must be able to unify constraints from all subprojects.
+
+Note: **`java-base` is necessary**, even on projects that don't have java source code, otherwise gradle will silently interpret the `platform(...)` dependency as if it was a normal library dependency, and will not import the constraints from that BOM.
 
 ### Specifying exact versions
 The preferred way to control your dependency graph is using [dependency constraints][] on gradle-consistent-versions' `rootConfiguration`. For example:


### PR DESCRIPTION
## Before this PR

People are confused as to why they don't get constraints from their BOMs.

## After this PR
==COMMIT_MSG==
README now mentions the need to apply `java-base` on all projects in order for BOMs to work.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

