### PR TITLE
More leninent checks

### DIFF
--- a/changelog/@unreleased/pr-187.v2.yml
+++ b/changelog/@unreleased/pr-187.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Only throw on configurations using `resolutionStrategy.failOnVersionConflict()`
+    if they are locked.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/187

--- a/src/main/java/com/palantir/gradle/versions/GradleWorkarounds.java
+++ b/src/main/java/com/palantir/gradle/versions/GradleWorkarounds.java
@@ -28,6 +28,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 import org.gradle.api.ProjectState;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
@@ -161,6 +162,13 @@ final class GradleWorkarounds {
         return nodesToStream(node.getChildNodes())
                 .flatMap(n -> (n instanceof Element) ? Stream.of(n) : Stream.of())
                 .collect(Collectors.toMap(Node::getNodeName, Node::getTextContent));
+    }
+
+    static boolean isFailOnVersionConflict(Configuration conf) {
+        org.gradle.api.internal.artifacts.configurations.ConflictResolution conflictResolution =
+                ((org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal)
+                         conf.getResolutionStrategy()).getConflictResolution();
+        return conflictResolution == org.gradle.api.internal.artifacts.configurations.ConflictResolution.strict;
     }
 
     static class Extractors {

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -431,11 +431,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
     }
 
     private static void ensureNoFailOnVersionConflict(Configuration conf) {
-        org.gradle.api.internal.artifacts.configurations.ConflictResolution conflictResolution =
-                ((org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal)
-                         conf.getResolutionStrategy()).getConflictResolution();
-        if (conflictResolution
-                == org.gradle.api.internal.artifacts.configurations.ConflictResolution.strict) {
+        if (GradleWorkarounds.isFailOnVersionConflict(conf)) {
             throw new GradleException("Must not use failOnVersionConflict() for " + conf);
         }
     }

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -406,12 +406,19 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 "Gradle Consistent Versions doesn't currently work with configure-on-demand, please remove"
                         + " 'org.gradle.configureondemand' from your gradle.properties");
 
+        Map<String, Project> projectCoordinates = new HashMap<>();
         project.subprojects(subproject -> {
             subproject.afterEvaluate(sub -> {
                 if (haveSameGroupAndName(project, sub)) {
                     throw new GradleException(String.format("This plugin doesn't work if the root project shares both "
                             + "group and name with a subproject. Consider adding the following to settings.gradle:\n"
                             + "rootProject.name = '%s-root'", project.getName()));
+                }
+                String coordinate = String.format("%s:%s", subproject.getGroup(), subproject.getName());
+                Project old = projectCoordinates.put(coordinate, subproject);
+                if (old != null) {
+                    throw new GradleException(String.format("All subprojects must have unique $group:$name "
+                            + "coordinates, but found duplicates: '%s' and '%s'", old, subproject));
                 }
             });
         });

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -418,23 +418,20 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
         project.subprojects(subproject -> {
             subproject.afterEvaluate(sub -> {
-                subproject
+                Configuration lockConstraints =
+                        subproject.getConfigurations().getByName(LOCK_CONSTRAINTS_CONFIGURATION_NAME);
+                project
                         .getConfigurations()
-                        .matching(conf -> conf.getName().equals(LOCK_CONSTRAINTS_CONFIGURATION_NAME))
-                        .all(lockConstraints -> {
-                            sub.getConfigurations().configureEach(conf -> {
-                                // Don't enforce this precondition on configurations that are not being locked.
-                                if (!conf.getExtendsFrom().contains(lockConstraints)) {
-                                    return;
-                                }
-                                org.gradle.api.internal.artifacts.configurations.ConflictResolution conflictResolution =
-                                        ((org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal)
-                                                 conf.getResolutionStrategy()).getConflictResolution();
-                                if (conflictResolution
-                                        == org.gradle.api.internal.artifacts.configurations.ConflictResolution.strict) {
-                                    throw new GradleException("Must not use failOnVersionConflict() for " + conf);
-                                }
-                            });
+                        // Don't enforce this precondition on configurations that are not being locked.
+                        .matching(conf -> conf.getExtendsFrom().contains(lockConstraints))
+                        .configureEach(conf -> {
+                            org.gradle.api.internal.artifacts.configurations.ConflictResolution conflictResolution =
+                                    ((org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal)
+                                             conf.getResolutionStrategy()).getConflictResolution();
+                            if (conflictResolution
+                                    == org.gradle.api.internal.artifacts.configurations.ConflictResolution.strict) {
+                                throw new GradleException("Must not use failOnVersionConflict() for " + conf);
+                            }
                         });
                 sub.getPluginManager().withPlugin("nebula.dependency-recommender", plugin -> {
                     RecommendationProviderContainer container =

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -418,7 +418,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 Project old = projectCoordinates.put(coordinate, subproject);
                 if (old != null) {
                     throw new GradleException(String.format("All subprojects must have unique $group:$name "
-                            + "coordinates, but found duplicates: '%s' and '%s'", old.getPath(), subproject.getPath()));
+                            + "coordinates, but found duplicates: '%s' and '%s'", old, subproject));
                 }
             });
         });

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -418,7 +418,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 Project old = projectCoordinates.put(coordinate, subproject);
                 if (old != null) {
                     throw new GradleException(String.format("All subprojects must have unique $group:$name "
-                            + "coordinates, but found duplicates: '%s' and '%s'", old, subproject));
+                            + "coordinates, but found duplicates: '%s' and '%s'", old.getPath(), subproject.getPath()));
                 }
             });
         });

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -406,19 +406,12 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 "Gradle Consistent Versions doesn't currently work with configure-on-demand, please remove"
                         + " 'org.gradle.configureondemand' from your gradle.properties");
 
-        Map<String, Project> projectCoordinates = new HashMap<>();
         project.subprojects(subproject -> {
             subproject.afterEvaluate(sub -> {
                 if (haveSameGroupAndName(project, sub)) {
                     throw new GradleException(String.format("This plugin doesn't work if the root project shares both "
                             + "group and name with a subproject. Consider adding the following to settings.gradle:\n"
                             + "rootProject.name = '%s-root'", project.getName()));
-                }
-                String coordinate = String.format("%s:%s", subproject.getGroup(), subproject.getName());
-                Project old = projectCoordinates.put(coordinate, subproject);
-                if (old != null) {
-                    throw new GradleException(String.format("All subprojects must have unique $group:$name "
-                            + "coordinates, but found duplicates: '%s' and '%s'", old, subproject));
                 }
             });
         });

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -291,6 +291,25 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         error.output.contains(expectedError)
     }
 
+    def 'fails fast when multiple subprojects share the same coordinate'() {
+        def expectedError = "All subprojects must have unique \$group:\$name"
+        buildFile << """
+            allprojects {
+                group 'same'
+            }
+        """.stripIndent()
+        // both projects will have name = 'a'
+        addSubproject("foo:a")
+        addSubproject("bar:a")
+        // Otherwise the lack of a lock file will throw first
+        file('versions.lock') << ""
+
+        expect:
+        def error = runTasksAndFail()
+        error.output.contains(expectedError)
+    }
+
+
     def 'fails if new dependency added that was not in the lock file'() {
         def expectedError = "Found dependencies that were not in the lock state"
         DependencyGraph dependencyGraph = new DependencyGraph("org:a:1.0", "org:b:1.0")

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -291,6 +291,33 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         error.output.contains(expectedError)
     }
 
+    def "detects failOnVersionConflict on locked configuration"() {
+        buildFile << """
+            apply plugin: 'java'    
+            configurations.compileClasspath.resolutionStrategy.failOnVersionConflict()
+        """.stripIndent()
+        file('versions.lock').text = ''
+
+        expect:
+        def failure = runTasksAndFail()
+        failure.output.contains('Must not use failOnVersionConflict')
+    }
+
+    def "ignores failOnVersionConflict on non-locked configuration"() {
+        buildFile << """
+            apply plugin: 'java'    
+            configurations {
+                foo {
+                    resolutionStrategy.failOnVersionConflict()
+                }
+            }
+        """.stripIndent()
+        file('versions.lock').text = ''
+
+        expect:
+        runTasks()
+    }
+
     def 'fails if new dependency added that was not in the lock file'() {
         def expectedError = "Found dependencies that were not in the lock state"
         DependencyGraph dependencyGraph = new DependencyGraph("org:a:1.0", "org:b:1.0")

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -291,25 +291,6 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         error.output.contains(expectedError)
     }
 
-    def 'fails fast when multiple subprojects share the same coordinate'() {
-        def expectedError = "All subprojects must have unique \$group:\$name"
-        buildFile << """
-            allprojects {
-                group 'same'
-            }
-        """.stripIndent()
-        // both projects will have name = 'a'
-        addSubproject("foo:a")
-        addSubproject("bar:a")
-        // Otherwise the lack of a lock file will throw first
-        file('versions.lock') << ""
-
-        expect:
-        def error = runTasksAndFail()
-        error.output.contains(expectedError)
-    }
-
-
     def 'fails if new dependency added that was not in the lock file'() {
         def expectedError = "Found dependencies that were not in the lock state"
         DependencyGraph dependencyGraph = new DependencyGraph("org:a:1.0", "org:b:1.0")


### PR DESCRIPTION
## Before this PR
Throwing if any configuration whatsoever uses `resolutionStrategy.failOnVersionConflict()`

## After this PR
==COMMIT_MSG==
Only throw on configurations using `resolutionStrategy.failOnVersionConflict()` if they are locked.

This allows configurations from random plugins / manually constructed by the user to continue existing as they are.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

