### PR TITLE
Fail fast if multiple subprojects share same coordinate

### DIFF
--- a/changelog/@unreleased/pr-188.v2.yml
+++ b/changelog/@unreleased/pr-188.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fail if _any_ projects share the same group:name coordinate.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/188

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -25,6 +25,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Streams;
 import com.palantir.gradle.versions.internal.MyModuleIdentifier;
 import com.palantir.gradle.versions.internal.MyModuleVersionIdentifier;
@@ -37,8 +40,10 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -406,12 +411,22 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 "Gradle Consistent Versions doesn't currently work with configure-on-demand, please remove"
                         + " 'org.gradle.configureondemand' from your gradle.properties");
 
+        Multimap<String, Project> coordinateDuplicates = LinkedHashMultimap.create();
+        Set<Project> subprojectsLeft = new HashSet<>(project.getSubprojects());
         project.subprojects(subproject -> {
             subproject.afterEvaluate(sub -> {
                 if (haveSameGroupAndName(project, sub)) {
                     throw new GradleException(String.format("This plugin doesn't work if the root project shares both "
                             + "group and name with a subproject. Consider adding the following to settings.gradle:\n"
                             + "rootProject.name = '%s-root'", project.getName()));
+                }
+                String coordinate = String.format("%s:%s", subproject.getGroup(), subproject.getName());
+                coordinateDuplicates.put(coordinate, subproject);
+
+                // Finally, check if there were any duplicates.
+                subprojectsLeft.remove(subproject);
+                if (subprojectsLeft.isEmpty()) {
+                    checkForDuplicatesInSubprojects(coordinateDuplicates);
                 }
             });
         });
@@ -437,6 +452,23 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 });
             });
         });
+    }
+
+    private static void checkForDuplicatesInSubprojects(Multimap<String, Project> coordinateDuplicates) {
+        Map<String, Collection<Project>> duplicates = ImmutableMap.copyOf(
+                Maps.filterValues(coordinateDuplicates.asMap(), projects -> projects.size() > 1));
+
+        if (!duplicates.isEmpty()) {
+            throw new GradleException(String.format(
+                    "All subprojects must have unique $group:$name coordinates, but found duplicates:\n%s",
+                    duplicates
+                            .entrySet()
+                            .stream()
+                            .map(entry -> String.format("- '%s' -> %s",
+                                    entry.getKey(),
+                                    Collections2.transform(entry.getValue(), Project::getPath)))
+                            .collect(Collectors.joining("\n"))));
+        }
     }
 
     /**

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -291,6 +291,24 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         error.output.contains(expectedError)
     }
 
+    def 'fails fast when multiple subprojects share the same coordinate'() {
+        def expectedError = "All subprojects must have unique \$group:\$name"
+        buildFile << """
+            allprojects {
+                group 'same'
+            }
+        """.stripIndent()
+        // both projects will have name = 'a'
+        addSubproject("foo:a")
+        addSubproject("bar:a")
+        // Otherwise the lack of a lock file will throw first
+        file('versions.lock') << ""
+
+        expect:
+        def error = runTasksAndFail()
+        error.output.contains(expectedError)
+    }
+
     def 'fails if new dependency added that was not in the lock file'() {
         def expectedError = "Found dependencies that were not in the lock state"
         DependencyGraph dependencyGraph = new DependencyGraph("org:a:1.0", "org:b:1.0")


### PR DESCRIPTION
## Before this PR
Only failing if a subproject shares the same `group:name` coordinate with the root project.

We didn't check if subprojects share a coordinate between themselves, which is also bad.

## After this PR
==COMMIT_MSG==
Fail if _any_ projects share the same group:name coordinate.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

