### PR TITLE
Don't publish constraints from versions.props

### DIFF
--- a/changelog/@unreleased/pr-193.v2.yml
+++ b/changelog/@unreleased/pr-193.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Properly remove versions.props constraints from being published.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/193

--- a/changelog/@unreleased/pr-193.v2.yml
+++ b/changelog/@unreleased/pr-193.v2.yml
@@ -1,5 +1,5 @@
-type: fix
-fix:
+type: improvement
+improvement:
   description: Properly remove versions.props constraints from being published.
   links:
   - https://github.com/palantir/gradle-consistent-versions/pull/193

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-5.6-20190522000044+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -29,5 +29,12 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
         project.getPluginManager().apply(VersionsLockPlugin.class);
         project.getPluginManager().apply(VersionsPropsPlugin.class);
         project.getPluginManager().apply(GetVersionPlugin.class);
+
+        project.allprojects(proj -> {
+            project.getPluginManager().withPlugin("java", plugin -> {
+                proj.getPluginManager().apply(FixLegacyJavaConfigurationsPlugin.class);
+            });
+        });
     }
+
 }

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -31,7 +31,7 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
         project.getPluginManager().apply(GetVersionPlugin.class);
 
         project.allprojects(proj -> {
-            project.getPluginManager().withPlugin("java", plugin -> {
+            proj.getPluginManager().withPlugin("java", plugin -> {
                 proj.getPluginManager().apply(FixLegacyJavaConfigurationsPlugin.class);
             });
         });

--- a/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
@@ -61,9 +61,12 @@ public class FixLegacyJavaConfigurationsPlugin implements Plugin<Project> {
                 JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME,
                 JavaPlugin.RUNTIME_CONFIGURATION_NAME)
                 .map(project.getConfigurations()::named)
-                .forEach(confProvider -> confProvider.configure(conf -> injectVersions(
-                        conf,
-                        (group, name) -> GetVersionPlugin.getOptionalVersion(project, group, name, unifiedClasspath))));
+                .forEach(confProvider -> confProvider.configure(conf -> {
+                    injectVersions(
+                            conf,
+                            (group, name) -> GetVersionPlugin.getOptionalVersion(
+                                    project, group, name, unifiedClasspath));
+                }));
     }
 
     private interface GetVersion {

--- a/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
@@ -33,7 +33,7 @@ import org.gradle.api.plugins.JavaPlugin;
 public class FixLegacyJavaConfigurationsPlugin implements Plugin<Project> {
     @Override
     public final void apply(Project project) {
-        if (!project.getPlugins().hasPlugin(VersionsLockPlugin.class)) {
+        if (!project.getRootProject().getPlugins().hasPlugin(VersionsLockPlugin.class)) {
             throw new GradleException("FixLegacyJavaConfigurationsPlugin must be applied after VersionsLockPlugin");
         }
 

--- a/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.versions;
 
+import com.google.common.base.Preconditions;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.gradle.api.GradleException;
@@ -34,9 +35,6 @@ import org.gradle.api.plugins.JavaPlugin;
 public class FixLegacyJavaConfigurationsPlugin implements Plugin<Project> {
     @Override
     public final void apply(Project project) {
-        if (!project.getRootProject().getPlugins().hasPlugin(VersionsLockPlugin.class)) {
-            throw new GradleException("FixLegacyJavaConfigurationsPlugin must be applied after VersionsLockPlugin");
-        }
         // ConsistentVersionsPlugin should ensure that we only get applied onto java projects
         if (!project.getPlugins().hasPlugin(JavaPlugin.class)) {
             throw new GradleException("FixLegacyJavaConfigurationsPlugin must be applied after 'java' / JavaPlugin");
@@ -49,7 +47,10 @@ public class FixLegacyJavaConfigurationsPlugin implements Plugin<Project> {
         Configuration unifiedClasspath = project
                 .getRootProject()
                 .getConfigurations()
-                .getByName(VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME);
+                .findByName(VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME);
+        Preconditions.checkNotNull(
+                unifiedClasspath,
+                "FixLegacyJavaConfigurationsPlugin must be applied after VersionsLockPlugin");
 
         fixLegacyResolvableJavaConfigurations(project, unifiedClasspath);
     }

--- a/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
@@ -102,7 +102,7 @@ public class FixLegacyJavaConfigurationsPlugin implements Plugin<Project> {
                 getVersion.getVersion(details.getRequested().getGroup(), details.getRequested().getName())
                         .ifPresent(ver -> {
                             details.useVersion(ver);
-                            details.because("Locked by gradle-consistent-versions versions.lock");
+                            details.because("Forced by gradle-consistent-versions versions.lock");
                         });
             });
         });

--- a/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
@@ -36,6 +36,10 @@ public class FixLegacyJavaConfigurationsPlugin implements Plugin<Project> {
         if (!project.getRootProject().getPlugins().hasPlugin(VersionsLockPlugin.class)) {
             throw new GradleException("FixLegacyJavaConfigurationsPlugin must be applied after VersionsLockPlugin");
         }
+        // ConsistentVersionsPlugin should ensure that we only get applied onto java projects
+        if (!project.getPlugins().hasPlugin(JavaPlugin.class)) {
+            throw new GradleException("FixLegacyJavaConfigurationsPlugin must be applied after 'java' / JavaPlugin");
+        }
 
         if (VersionsLockPlugin.isIgnoreLockFile(project)) {
             return;

--- a/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/FixLegacyJavaConfigurationsPlugin.java
@@ -1,0 +1,99 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions;
+
+import java.util.stream.Stream;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleVersionSelector;
+import org.gradle.api.artifacts.ResolvableDependencies;
+import org.gradle.api.plugins.JavaPlugin;
+
+/**
+ * This plugin exists in order to ensure versions in legacy java configurations (that are still
+ * {@link Configuration#isCanBeResolved() resolvable} for compatibility reasons) can be resolved, and that they use
+ * the locked versions.
+ */
+public class FixLegacyJavaConfigurationsPlugin implements Plugin<Project> {
+    @Override
+    public final void apply(Project project) {
+        if (!project.getPlugins().hasPlugin(VersionsLockPlugin.class)) {
+            throw new GradleException("FixLegacyJavaConfigurationsPlugin must be applied after VersionsLockPlugin");
+        }
+
+        if (VersionsLockPlugin.isIgnoreLockFile(project)) {
+            return;
+        }
+
+        Configuration unifiedClasspath = project
+                .getRootProject()
+                .getConfigurations()
+                .getByName(VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME);
+
+        fixLegacyResolvableJavaConfigurations(project, unifiedClasspath);
+    }
+
+    private void fixLegacyResolvableJavaConfigurations(Project project, Configuration unifiedClasspath) {
+        Stream.of(
+                JavaPlugin.COMPILE_CONFIGURATION_NAME,
+                JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME,
+                JavaPlugin.RUNTIME_CONFIGURATION_NAME)
+                .map(project.getConfigurations()::named)
+                .forEach(confProvider -> confProvider.configure(conf -> injectVersions(
+                        conf,
+                        (group, name) -> GetVersionPlugin.getVersion(project, group, name, unifiedClasspath))));
+    }
+
+    private interface GetVersion {
+        String getVersion(String group, String name);
+    }
+
+    /**
+     * Inject versions of _all_ dependencies into the given {@code conf}, by polling the {@code getVersion}.
+     */
+    private void injectVersions(Configuration conf, GetVersion getVersion) {
+        ResolvableDependencies incoming = conf.getIncoming();
+        incoming.beforeResolve(dependencies -> {
+            // Bail if this is a copied configuration.
+            if (incoming != dependencies) {
+                return;
+            }
+            // Code adapted from:
+            // https://github.com/nebula-plugins/nebula-dependency-recommender-plugin/blob/64ed7c6853f80b909918e6a595231a5e9803ae8b/src/main/groovy/netflix/nebula/dependency/recommender/DependencyRecommendationsPlugin.java
+            conf.getResolutionStrategy().eachDependency(details -> {
+                ModuleVersionSelector requested = details.getTarget();
+
+                // don't interfere with the way forces trump everything
+                for (ModuleVersionSelector force : conf.getResolutionStrategy().getForcedModules()) {
+                    if (requested.getGroup().equals(force.getGroup()) && requested.getName().equals(force.getName())) {
+                        details.because(String.format(
+                                "Would have recommended a version for %s:%s, but a force is in place",
+                                requested.getGroup(),
+                                requested.getName()));
+                        return;
+                    }
+                }
+
+                String ver = getVersion.getVersion(details.getRequested().getGroup(), details.getRequested().getName());
+                details.useVersion(ver);
+                details.because("Locked by gradle-consistent-versions versions.lock");
+            });
+        });
+    }
+}

--- a/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
@@ -70,7 +70,7 @@ public final class GetVersionPlugin implements Plugin<Project> {
         });
     }
 
-    private static String getVersion(Project project, String group, String name, Configuration configuration) {
+    static String getVersion(Project project, String group, String name, Configuration configuration) {
         if (GradleWorkarounds.isConfiguring(project.getState())) {
             throw new GradleException(
                     String.format("Not allowed to call gradle-consistent-versions's getVersion(\"%s\", \"%s\", "

--- a/src/main/java/com/palantir/gradle/versions/GradleWorkarounds.java
+++ b/src/main/java/com/palantir/gradle/versions/GradleWorkarounds.java
@@ -16,17 +16,9 @@
 
 package com.palantir.gradle.versions;
 
-import com.google.common.collect.Maps;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 import javax.inject.Inject;
 import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.GradleException;
@@ -45,10 +37,6 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.util.GradleVersion;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 @SuppressWarnings("UnstableApiUsage")
 final class GradleWorkarounds {
@@ -143,59 +131,6 @@ final class GradleWorkarounds {
         return dependency;
     }
 
-    static void mergeImportsWithVersions(Element root) {
-        Document doc = root.getOwnerDocument();
-        Optional<Node> dependenciesNode =
-                getSubnode(root, "dependencyManagement").flatMap(n -> getSubnode(n, "dependencies"));
-        if (!dependenciesNode.isPresent()) {
-            return;
-        }
-        Stream<Node> dependencies = nodesToStream(dependenciesNode.get().getChildNodes())
-                .filter(node -> "dependency".equals(node.getNodeName()));
-        Map<String, List<Node>> dependenciesByCoordinate = dependencies
-                .flatMap(node -> {
-                    Map<String, String> map = parseDependencyNode(node);
-                    String groupId = map.get("groupId");
-                    String artifactId = map.get("artifactId");
-                    if (artifactId == null || groupId == null) {
-                        return Stream.of();
-                    }
-                    String key = groupId + ":" + artifactId;
-                    return Stream.of(Maps.immutableEntry(key, node));
-                })
-                .collect(Collectors.groupingBy(
-                        Map.Entry::getKey,
-                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
-
-        dependenciesByCoordinate.values().stream().filter(nodes -> nodes.size() > 1).forEach(nodes -> {
-            // Is there a node under scope `import` but without a version?
-            Optional<Node> badImportingNode =
-                    nodes.stream()
-                            .filter(n -> {
-                                Map<String, String> map = parseDependencyNode(n);
-                                return Objects.equals("import", map.get("scope")) && !map.containsKey("version");
-                            }).findAny();
-            badImportingNode.ifPresent(importingNode -> {
-                Node nodeWithVersion = nodes
-                        .stream()
-                        .filter(n -> {
-                            Map<String, String> map = parseDependencyNode(n);
-                            return map.containsKey("version");
-                        })
-                        .findAny()
-                        .orElseThrow(() -> new RuntimeException("Couldn't find dependencyManagement node that "
-                                + "specifies a version for this import node: " + importingNode));
-                Map<String, String> nodeWithVersionMap = parseDependencyNode(nodeWithVersion);
-                if (nodes.size() > 2) {
-                    throw new RuntimeException("Did not expect more than two conflicting nodes in "
-                            + "dependencyManagement: " + nodes);
-                }
-                nodeWithVersion.getParentNode().removeChild(nodeWithVersion);
-                importingNode.appendChild(createProperty(doc, "version", nodeWithVersionMap.get("version")));
-            });
-        });
-    }
-
     /**
      * Returns whether a dependency / component is a non-enforced platform, i.e. what you create with
      * {@link DependencyHandler#platform} or {@link DependencyConstraintHandler#platform}.
@@ -215,27 +150,6 @@ final class GradleWorkarounds {
     private static boolean isPlatformPre53(AttributeContainer attributes) {
         String category = attributes.getAttribute(OLD_COMPONENT_CATEGORY);
         return category != null && category.equals("platform");
-    }
-
-    private static Element createProperty(Document doc, String groupId, String text) {
-        Element element = doc.createElement(groupId);
-        element.setTextContent(text);
-        return element;
-    }
-
-    private static Stream<Node> nodesToStream(NodeList nodes) {
-        return IntStream.range(0, nodes.getLength()).mapToObj(nodes::item);
-    }
-
-    private static Optional<Node> getSubnode(Node node, String subnodeName) {
-        NodeList childNodes = node.getChildNodes();
-        return nodesToStream(childNodes).filter(n -> subnodeName.equals(n.getNodeName())).findAny();
-    }
-
-    private static Map<String, String> parseDependencyNode(Node node) {
-        return nodesToStream(node.getChildNodes())
-                .flatMap(n -> (n instanceof Element) ? Stream.of(n) : Stream.of())
-                .collect(Collectors.toMap(Node::getNodeName, Node::getTextContent));
     }
 
     static boolean isFailOnVersionConflict(Configuration conf) {

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -267,7 +267,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 Map<Project, LockedConfigurations> lockedConfigurations = wireUpLockedConfigurationsByProject(project);
                 recursivelyCopyProjectDependencies(project, unifiedClasspath.getIncoming().getDependencies());
 
-                if (project.hasProperty("ignoreLockFile")) {
+                if (isIgnoreLockFile(project)) {
                     log.lifecycle("Ignoring lock file for debugging, because the 'ignoreLockFile' property was set");
                     return;
                 }
@@ -293,6 +293,10 @@ public class VersionsLockPlugin implements Plugin<Project> {
             t.lockfile(rootLockfile);
             t.fullLockState(project.provider(fullLockStateSupplier::get));
         });
+    }
+
+    static boolean isIgnoreLockFile(Project project) {
+        return project.hasProperty("ignoreLockFile");
     }
 
     private static Map<Project, LockedConfigurations> wireUpLockedConfigurationsByProject(Project rootProject) {

--- a/src/main/java/com/palantir/gradle/versions/VersionsProps.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsProps.java
@@ -83,7 +83,7 @@ public final class VersionsProps {
      * This is necessary for direct dependency injection, which is not supported by virtual platforms.
      * See <a href=https://github.com/gradle/gradle/issues/7954>gradle#7954</a> for more details.
      */
-    public Optional<String> getRecommendedVersion(ModuleIdentifier dependency) {
+    public Optional<String> getStarVersion(ModuleIdentifier dependency) {
         String notation = dependency.getGroup() + ":" + dependency.getName();
         return Optional.ofNullable(fuzzyResolver.patternFor(notation)).map(fuzzyResolver.versions()::get);
     }

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.versions;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -45,7 +46,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
     private static final Logger log = Logging.getLogger(VersionsPropsPlugin.class);
     private static final String ROOT_CONFIGURATION_NAME = "rootConfiguration";
     private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("5.2");
-    private static final ImmutableList<String> JAVA_PUBLISHED_CONFIGURATION_NAMES = ImmutableList.of(
+    private static final ImmutableSet<String> JAVA_PUBLISHED_CONFIGURATION_NAMES = ImmutableSet.of(
             JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME,
             JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME);
 
@@ -122,7 +123,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                 return;
             }
 
-            if (JAVA_PUBLISHED_CONFIGURATION_NAMES.stream().anyMatch(conf.getName()::equals)) {
+            if (JAVA_PUBLISHED_CONFIGURATION_NAMES.contains(conf.getName())) {
                 log.debug("Only configuring BOM dependencies on published java configuration: {}", conf);
                 deps.addAllLater(extractPlatformDependencies(subproject, rootConfiguration));
                 return;

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -45,7 +45,7 @@ import org.gradle.util.GradleVersion;
 public class VersionsPropsPlugin implements Plugin<Project> {
     private static final Logger log = Logging.getLogger(VersionsPropsPlugin.class);
     private static final String ROOT_CONFIGURATION_NAME = "rootConfiguration";
-    private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("5.1");
+    private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("5.2");
     private static final ImmutableList<String> JAVA_PUBLISHED_CONFIGURATION_NAMES = ImmutableList.of(
             JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME,
             JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME);

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -22,7 +22,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Stream;
 import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
@@ -57,8 +56,6 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             applyToRootProject(project);
         }
 
-        fixLegacyResolvableJavaConfigurations(project);
-
         VersionRecommendationsExtension extension =
                 project.getRootProject().getExtensions().getByType(VersionRecommendationsExtension.class);
 
@@ -90,17 +87,6 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         project.getDependencies()
                 .getComponents()
                 .all(component -> tryAssignComponentToPlatform(versionsProps, component));
-    }
-
-    private void fixLegacyResolvableJavaConfigurations(Project project) {
-        project.getPluginManager().withPlugin("java", plugin -> {
-            Stream.of(
-                JavaPlugin.COMPILE_CONFIGURATION_NAME,
-                JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME,
-                JavaPlugin.RUNTIME_CONFIGURATION_NAME)
-                .map(project.getConfigurations()::named)
-                .forEach(confProvider -> confProvider.configure(conf -> conf.setCanBeResolved(false)));
-        });
     }
 
     private static void applyToRootProject(Project project) {

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -158,6 +158,11 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                 return;
             }
 
+            // This will ensure that dependencies declared in almost all configurations - including ancestors of
+            // published configurations (such as `compile`, `runtimeOnly`) - have a version if there only
+            // a star-constraint in versions.props that matches them.
+            configureDirectDependencyInjection(versionsProps, deps);
+
             // But don't configure any _ancestors_ of our published configurations to extend rootConfiguration, as we
             // explicitly DO NOT WANT to republish the constraints that come from it (that come from versions.props).
             if (JAVA_PUBLISHED_CONFIGURATION_NAMES
@@ -167,11 +172,6 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                 log.debug("Not configuring published java configuration or its ancestor: {}", conf);
                 return;
             }
-
-            // This will ensure that dependencies declared in almost all configurations - those that are NOT
-            // ancestors of published configurations (such as `compile`, `runtimeOnly`) - have a version if there only
-            // a star-constraint in versions.props that matches them.
-            configureDirectDependencyInjection(versionsProps, deps);
 
             conf.extendsFrom(rootConfiguration);
         });

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -20,9 +20,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
@@ -123,9 +122,9 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         // afterEvaluate, leading to sadness.
         // This way however, we guarantee that this is evaluated exactly once and right at the moment when
         // conf.getDependencies() is called.
-        Set<Configuration> configuredConfigurations = new HashSet<>();
+        AtomicBoolean wasConfigured = new AtomicBoolean();
         conf.withDependencies(deps -> {
-            if (!configuredConfigurations.add(conf)) {
+            if (!wasConfigured.compareAndSet(false, true)) {
                 // We are configuring a copy of the original dependency, as they inherit the withDependenciesActions.
                 log.debug("Not configuring {} because it's a copy of an already configured configuration.", conf);
                 return;

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -40,8 +40,6 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.publish.PublishingExtension;
-import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.util.GradleVersion;
 
 public class VersionsPropsPlugin implements Plugin<Project> {
@@ -92,20 +90,6 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         project.getDependencies()
                 .getComponents()
                 .all(component -> tryAssignComponentToPlatform(versionsProps, component));
-
-        // Gradle 5.1 has a bug whereby a platform dependency whose version comes from a separate constraint end
-        // up as two separate entries in the resulting POM, making it invalid.
-        // https://github.com/gradle/gradle/issues/8238
-        project.getPluginManager().withPlugin("publishing", plugin -> {
-            PublishingExtension publishingExtension =
-                    project.getExtensions().getByType(PublishingExtension.class);
-            publishingExtension.getPublications().withType(MavenPublication.class, publication -> {
-                log.info("Fixing pom publication for {}: {}", project, publication);
-                publication.getPom().withXml(xmlProvider -> {
-                    GradleWorkarounds.mergeImportsWithVersions(xmlProvider.asElement());
-                });
-            });
-        });
     }
 
     private void fixLegacyResolvableJavaConfigurations(Project project) {

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -204,7 +204,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             versionsProps
                     .getRecommendedVersion(moduleDependency.getModule())
                     .ifPresent(version -> moduleDependency.version(constraint -> {
-                        log.info("Found direct dependency without version: {} -> {}, requiring: {}",
+                        log.debug("Found direct dependency without version: {} -> {}, requiring: {}",
                                 deps, moduleDependency, version);
                         constraint.require(version);
                     }));

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -62,6 +62,26 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         runTasks('resolveConfigurations')
     }
 
+    def 'can resolve all configurations like compile with version coming only from versions props'() {
+        file('versions.props') << """
+            org.slf4j:slf4j-api:1.7.22
+        """.stripIndent()
+
+        buildFile << """
+            apply plugin: 'java'
+            dependencies {
+                compile "org.slf4j:slf4j-api"
+            }
+        """.stripIndent()
+
+        when:
+        runTasks('--write-locks')
+
+        then:
+        // Ensures that configurations like 'compile' are resolved and their dependencies have versions
+        runTasks('resolveConfigurations')
+    }
+
     def "locks are consistent whether or not we do --write-locks for glob-forced direct dependency"() {
         buildFile << '''
             apply plugin: 'java'

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -209,10 +209,6 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         when:
         runTasks('--write-locks', 'generateMetadataFileForMavenPublication')
 
-        def logbackDepWithoutVersion = new MetadataFile.Dependency(
-                group: 'ch.qos.logback',
-                module: 'logback-classic',
-                version: [:])
         def logbackDep = new MetadataFile.Dependency(
                 group: 'ch.qos.logback',
                 module: 'logback-classic',
@@ -229,11 +225,11 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         fooMetadata.variants == [
                 new MetadataFile.Variant(
                         name: 'apiElements',
-                        dependencies: [logbackDepWithoutVersion],
+                        dependencies: [logbackDep],
                         dependencyConstraints: [logbackDep, slf4jDep]),
                 new MetadataFile.Variant(
                         name: 'runtimeElements',
-                        dependencies: [logbackDepWithoutVersion],
+                        dependencies: [logbackDep],
                         dependencyConstraints: [logbackDep, slf4jDep]),
         ] as Set
     }

--- a/src/test/groovy/com/palantir/gradle/versions/IntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/IntegrationSpec.groovy
@@ -24,6 +24,7 @@ import nebula.test.dependencies.GradleDependencyGenerator
 class IntegrationSpec extends IntegrationTestKitSpec {
     void setup() {
         keepFiles = true
+        debug = true
         settingsFile.createNewFile()
     }
 

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -140,7 +140,7 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
             apply plugin: 'java-library'
             apply plugin: 'maven-publish'
             dependencies {
-                compile platform('org.apache.spark:spark-dist_2.11-hadoop-palantir-bom')
+                rootConfiguration platform('org.apache.spark:spark-dist_2.11-hadoop-palantir-bom')
             }
             publishing {
                 publications {

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -96,7 +96,7 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
         addSubproject('foo', """
             apply plugin: 'java'
             dependencies {
-                compile 'ch.qos.logback:logback-classic'
+                implementation 'ch.qos.logback:logback-classic'
             }
         """.stripIndent())
 
@@ -117,7 +117,7 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
         addSubproject('foo', """
             apply plugin: 'java'
             dependencies {
-                compile 'ch.qos.logback:logback-classic'
+                implementation 'ch.qos.logback:logback-classic'
             }
         """.stripIndent())
 

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -128,11 +128,9 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
     }
 
     def 'imported platform generated correctly in pom'() {
-        debug = true
-        keepFiles = true
         file("versions.props") << """
             org.apache.spark:spark-dist_2.11-hadoop-palantir-bom = 2.5.0-palantir.7
-            # Just to make sure this doesn't get removed from the constraints
+            # This shouldn't end up in the POM
             other:constraint = 1.0.0
         """.stripIndent()
 
@@ -167,12 +165,6 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
                         scope: 'import',
                         type: 'pom'
                 ],
-                [
-                        groupId: 'other',
-                        artifactId: 'constraint',
-                        version: '1.0.0',
-                        scope: 'compile',
-                ]
         ] as Set
     }
 

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -144,6 +144,11 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
                 publications {
                     main(MavenPublication) {
                         from components.java
+                        versionMapping {
+                            allVariants {
+                                fromResolutionResult()
+                            }
+                        }
                     }
                 }
             }

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -35,6 +35,7 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
                 "com.fasterxml.jackson.core:jackson-annotations:2.9.0",
                 "com.fasterxml.jackson.core:jackson-annotations:2.9.7",
                 "com.fasterxml.jackson.core:jackson-databind:2.9.7",
+                "org:platform:1.0",
         )
         buildFile << """
             buildscript {
@@ -129,7 +130,7 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
 
     def 'imported platform generated correctly in pom'() {
         file("versions.props") << """
-            org.apache.spark:spark-dist_2.11-hadoop-palantir-bom = 2.5.0-palantir.7
+            org:platform = 1.0
             # This shouldn't end up in the POM
             other:constraint = 1.0.0
         """.stripIndent()
@@ -138,7 +139,7 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
             apply plugin: 'java-library'
             apply plugin: 'maven-publish'
             dependencies {
-                rootConfiguration platform('org.apache.spark:spark-dist_2.11-hadoop-palantir-bom')
+                rootConfiguration platform('org:platform')
             }
             publishing {
                 publications {
@@ -164,9 +165,9 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
         NodeChildren dependencies = pom.dependencyManagement.dependencies.dependency
         dependencies.collect { convertToMap(it) } as Set == [
                 [
-                        groupId: 'org.apache.spark',
-                        artifactId: 'spark-dist_2.11-hadoop-palantir-bom',
-                        version: '2.5.0-palantir.7',
+                        groupId: 'org',
+                        artifactId: 'platform',
+                        version: '1.0',
                         scope: 'import',
                         type: 'pom'
                 ],


### PR DESCRIPTION
## Before this PR

#191 failed to properly remove versions.props constraints from being published.

This is because they were still being inherited by the published `apiElements`, `runtimeElements` configurations, through other configurations like `runtime`, `implementation` etc.

## After this PR
==COMMIT_MSG==
Properly remove versions.props constraints from being published. This makes us now compatible with gradle metadata.

This is done by not configuring versions.props constraints on _any_ configuration that `apiElements` or `runtimeElements` extends from.

In order to maintain resolvability of the legacy configurations `compile`, `runtime` and `compileOnly`, we inject their versions at resolution time in the same way that nebula-dependency-recommender works.
We can't apply constraints on them anymore because they ancestors of the published configurations and so those constraints would be published.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

