### PR TITLE
Fix error writing lock file in the presence of platform dependencies

### DIFF
--- a/changelog/@unreleased/pr-195.v2.yml
+++ b/changelog/@unreleased/pr-195.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix error writing lock file in the presence of platform dependencies
+    coming from `rootConfiguration`.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/195

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -520,6 +520,11 @@ public class VersionsLockPlugin implements Plugin<Project> {
                         return;
                     }
 
+                    // Necessary to run withDependency actions run on the targetConf, because VersionsPropsPlugin
+                    // configures its constraints that way.
+                    // Without this, they'd just be propagated to the copiedConf and probably never run!
+                    causeWithDependenciesActionsToRun(targetConf);
+
                     Configuration copiedConf = targetConf.copyRecursive();
                     copiedConf.setDescription(String.format("Copy of the '%s' configuration that can be resolved by "
                                     + "com.palantir.consistent-versions without resolving the '%s' configuration "
@@ -563,6 +568,15 @@ public class VersionsLockPlugin implements Plugin<Project> {
                     recursivelyCopyProjectDependenciesWithScope(
                             projectDep, copiedConf.getDependencies(), copiedConfigurationsCache, scope);
                 });
+    }
+
+    /**
+     * This causes {@link Configuration#withDependencies} actions to be run eagerly.
+     * <p>
+     * It's a hack but necessary to ensure that these actions run before copying said configuration.
+     */
+    private static void causeWithDependenciesActionsToRun(Configuration conf) {
+        conf.getIncoming().getDependencies();
     }
 
     private static Configuration getTargetConfiguration(DependencySet depSet, ProjectDependency projectDependency) {

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -495,9 +495,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
             Map<Configuration, String> copiedConfigurationsCache,
             GcvScope scope) {
         dependencySet
-                .matching(dependency -> ProjectDependency.class.isAssignableFrom(dependency.getClass()))
-                .all(dependency -> {
-                    ProjectDependency projectDependency = (ProjectDependency) dependency;
+                .withType(ProjectDependency.class)
+                .all(projectDependency -> {
                     Project projectDep = projectDependency.getDependencyProject();
 
                     String targetConfiguration = projectDependency.getTargetConfiguration();
@@ -551,9 +550,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
                     // This is so we can get back the scope from the ResolutionResult.
                     copiedConf
                             .getDependencies()
-                            .matching(dep -> dep instanceof ExternalModuleDependency)
-                            .all(dep -> {
-                                ExternalModuleDependency externalDep = (ExternalModuleDependency) dep;
+                            .withType(ExternalModuleDependency.class)
+                            .all(externalDep -> {
                                 GradleWorkarounds.fixAttributesOfModuleDependency(projectDep.getObjects(), externalDep);
                                 externalDep.attributes(attr -> attr.attribute(GCV_SCOPE_ATTRIBUTE, scope));
                             });

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -20,9 +20,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
@@ -127,9 +126,9 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         // afterEvaluate, leading to sadness.
         // This way however, we guarantee that this is evaluated exactly once and right at the moment when
         // conf.getDependencies() is called.
-        Set<Configuration> configuredConfigurations = new HashSet<>();
+        AtomicBoolean wasConfigured = new AtomicBoolean();
         conf.withDependencies(deps -> {
-            if (!configuredConfigurations.add(conf)) {
+            if (!wasConfigured.compareAndSet(false, true)) {
                 // We are configuring a copy of the original dependency, as they inherit the withDependenciesActions.
                 log.debug("Not configuring {} because it's a copy of an already configured configuration.", conf);
                 return;

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -172,4 +172,46 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         // Ensure that this is a required constraint
         runTasks('why', '--hash', '4105483b').output.contains "projects -> 1.7.25"
     }
+
+    def "writeLocks and verifyLocks work in the presence of versions props constraints"() {
+        generateMavenRepo(
+                "org1:platform:1.0",
+                "org2:platform:1.0",
+        )
+        addSubproject('foo', """
+            apply plugin: 'java'
+            dependencies {
+                compile 'org.slf4j:slf4j-api'
+                
+                rootConfiguration platform('org1:platform')
+                rootConfiguration platform('org2:platform')
+            }
+            
+            task resolveLockedConfigurations {
+                doLast {
+                    configurations.compileClasspath.resolve()
+                    configurations.runtimeClasspath.resolve()
+                }
+            }
+        """.stripIndent())
+
+        file('versions.props') << """
+            org1:platform = 1.0
+            org2:* = 1.0
+            org.slf4j:slf4j-api = 1.7.25
+        """.stripIndent()
+
+        expect:
+        runTasks('--write-locks')
+
+        file('versions.lock').text == """\
+            # Run ./gradlew --write-locks to regenerate this file
+            org.slf4j:slf4j-api:1.7.25 (1 constraints: 4105483b)
+            org1:platform:1.0 (1 constraints: a5041a2c)
+            org2:platform:1.0 (1 constraints: a5041a2c)
+        """.stripIndent()
+
+        and: 'Ensure you can verify locks and resolve the actual locked configurations'
+        runTasks('verifyLocks', 'resolveLockedConfigurations')
+    }
 }


### PR DESCRIPTION
## Before this PR

#191 moved the main VersionsPropsPlugin actions to a lazy `withDependencies` block, however for locked configurations (e.g. compileClasspath, runtimeClasspath) that get copied by `VersionsLockPlugin` (for the purposes of computing the lock file), this was being run too late, because copying a configuration doesn't automatically run its `withDependencies` actions.

That resulted in important instrumentation that runs eagerly (attaching production/test scope to the dependencies themselves) not running on dependencies inherited from `rootConfiguration`, and thus in errors like:
```
Couldn't determine scope for dependency: com.palantir.foo:foo-bom:1.1.0
```

## After this PR
==COMMIT_MSG==
Fix error writing lock file in the presence of platform dependencies coming from `rootConfiguration`.

Fixes #194, a regression introduced in 1.11.0.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

