### PR TITLE
Fix other regression with BOMs

### DIFF
--- a/changelog/@unreleased/pr-197.v2.yml
+++ b/changelog/@unreleased/pr-197.v2.yml
@@ -1,0 +1,12 @@
+type: fix
+fix:
+  description: |-
+    Fix regression from 1.11.0 where non-locked configurations could not resolve a `platform()` dependency if its constraint was declared using a `*` in `versions.props`.
+
+    Example:
+    ```
+    Could not resolve all files for configuration ':some-api:conjureJava'.
+       > Could not find com.palantir.witchcraft:witchcraft-core-bom:.
+    ```
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/197

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -68,6 +68,10 @@ public class VersionsPropsPlugin implements Plugin<Project> {
 
         project.getConfigurations().configureEach(conf -> {
             if (conf.getName().equals(ROOT_CONFIGURATION_NAME)) {
+                // We only expect 'platform' dependencies to be declared in rootConfiguration.
+                // This injects missing versions, in case the version comes from a *-dependency in versions.props.
+                // For rootConfiguration, unlike other configurations, this is the only customization necessary.
+                conf.withDependencies(deps -> configureDirectDependencyInjection(versionsProps, deps));
                 return;
             }
             setupConfiguration(project, extension, rootConfiguration.get(), versionsProps, conf);
@@ -174,6 +178,9 @@ public class VersionsPropsPlugin implements Plugin<Project> {
     /**
      * For dependencies inside {@code deps} that don't have a version, sets a version if there is a corresponding
      * platform constraint (one containing at least a {@code *} character).
+     * <p>
+     * This is necessary because virtual platforms don't do dependency injection, see
+     * <a href=https://github.com/gradle/gradle/issues/7954>gradle/gradle#7954</a>
      */
     private static void configureDirectDependencyInjection(VersionsProps versionsProps, DependencySet deps) {
         deps.withType(ExternalDependency.class).configureEach(moduleDependency -> {

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -180,17 +180,29 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         )
         addSubproject('foo', """
             apply plugin: 'java'
+            
+            configurations {
+                other
+            }
+            
             dependencies {
                 compile 'org.slf4j:slf4j-api'
                 
                 rootConfiguration platform('org1:platform')
                 rootConfiguration platform('org2:platform')
             }
-            
+  
             task resolveLockedConfigurations {
                 doLast {
                     configurations.compileClasspath.resolve()
                     configurations.runtimeClasspath.resolve()
+                }
+            }
+            
+            // This is to ensure that the platform deps are successfully resolvable on a non-locked configuration
+            task resolveNonLockedConfiguration {
+                doLast {
+                    configurations.other.resolve()
                 }
             }
         """.stripIndent())
@@ -212,6 +224,6 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         and: 'Ensure you can verify locks and resolve the actual locked configurations'
-        runTasks('verifyLocks', 'resolveLockedConfigurations')
+        runTasks('verifyLocks', 'resolveLockedConfigurations', 'resolveNonLockedConfiguration')
     }
 }

--- a/src/test/groovy/com/palantir/gradle/versions/SlsPackagingCompatibilityIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/SlsPackagingCompatibilityIntegrationSpec.groovy
@@ -1,0 +1,113 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions
+
+
+import org.gradle.testkit.runner.TaskOutcome
+
+/**
+ * https://github.com/palantir/sls-packaging does some funky stuff when resolving inter-project dependencies for the
+ * purposes of detecting published recommended product dependencies, so we want to make double sure that GCV doesn't
+ * accidentally break it.
+ */
+class SlsPackagingCompatibilityIntegrationSpec extends IntegrationSpec {
+
+    static def PLUGIN_NAME = "com.palantir.consistent-versions"
+
+    void setup() {
+        File mavenRepo = generateMavenRepo(
+                "org.slf4j:slf4j-api:1.7.24",
+        )
+        buildFile << """
+            buildscript {
+                repositories {
+                    maven { url 'https://dl.bintray.com/palantir/releases' }
+                }
+            }            
+            plugins {
+                id '${PLUGIN_NAME}'
+                id 'com.palantir.sls-java-service-distribution' version '3.8.1' apply false
+            }
+            allprojects {
+                repositories {
+                    maven { url "file:///${mavenRepo.getAbsolutePath()}" }
+                }
+            }
+        """.stripIndent()
+    }
+
+    def 'can consume recommended product dependencies project'() {
+        setup:
+        file("versions.props") << """
+            org.slf4j:* = 1.7.24
+        """.stripIndent()
+
+        buildFile << """
+            allprojects {
+                version = '1.0.0'
+            }
+        """.stripIndent()
+
+        addSubproject('api', """
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.sls-recommended-dependencies'
+            
+            dependencies {
+                compile 'org.slf4j:slf4j-api'
+            }
+            
+            recommendedProductDependencies {
+                productDependency {
+                    productGroup = 'org'
+                    productName = 'product'
+                    minimumVersion = '1.1.0'
+                    maximumVersion = '1.x.x'
+                }
+            }
+            
+            configurations.runtimeClasspath.incoming.beforeResolve {
+                // Signal that this configuration was resolved, which we expect, because this project is expected to be
+                // consumed as part of createManifest, and `runtimeElements` triggers resolution of `runtimeClasspath`
+                buildDir.mkdirs()
+                file("\$buildDir/resolved-runtime").text = 'done'
+            }
+        """.stripIndent())
+
+        addSubproject('service', """
+            apply plugin: 'java'
+            apply plugin: 'com.palantir.sls-java-service-distribution'
+            
+            dependencies {
+                // Gets picked up by the productDependenciesConfig which is runtimeClasspath
+                compile project(':api')
+            }
+        """.stripIndent())
+
+        expect:
+        def wroteLocks = runTasks('--write-locks')
+        // Maybe this is a bit too much but for a fixed version of sls-packaging, we expect this to not change
+        wroteLocks.tasks(TaskOutcome.SUCCESS).collect { it.path } as Set == [
+                ':service:createManifest',
+                ':api:configureProductDependencies',
+        ] as Set
+        // Ensure that 'jar' was not run on the API project
+        wroteLocks.task(':api:jar') == null
+        new File(projectDir, 'api/build/resolved-runtime').exists()
+
+        runTasks('createManifest', 'verifyLocks')
+    }
+}


### PR DESCRIPTION
## Before this PR
#191 introduced a regression that broke injecting versions into BOMs declared in `rootConfiguration`.
#195 fixed this somewhat, but only for the locked configurations, thanks to the VersionsLockPlugin. Non-locked configurations like `conjureJava` still got the platform dependency and failed to resolve it (as evidenced by the [failing test](https://circleci.com/gh/palantir/gradle-consistent-versions/1876?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) in the first commit).

## After this PR
==COMMIT_MSG==
Fix regression from 1.11.0 where non-locked configurations could not resolve a `platform()` dependency if its constraint was declared using a `*` in `versions.props`.

Example:
```
Could not resolve all files for configuration ':some-api:conjureJava'.
   > Could not find com.palantir.witchcraft:witchcraft-core-bom:.
```
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

