### PR TITLE
sunset workaround for gradle#9653 which merged in June

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-5.6-20190522000044+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/palantir/gradle/versions/GradleWorkarounds.java
+++ b/src/main/java/com/palantir/gradle/versions/GradleWorkarounds.java
@@ -121,7 +121,7 @@ final class GradleWorkarounds {
      */
     static <T extends ModuleDependency> T fixAttributesOfModuleDependency(
             ObjectFactory objectFactory, T dependency) {
-        if (GradleVersion.current().compareTo(GradleVersion.version("5.6-rc-1")) >= 0
+        if (GradleVersion.current().compareTo(GradleVersion.version("5.6")) >= 0
                 // Merged on 2019-06-12 so next nightly should be good
                 || GradleVersion.current().compareTo(GradleVersion.version("5.6-20190613000000+0000")) >= 0) {
             return dependency;

--- a/src/main/java/com/palantir/gradle/versions/GradleWorkarounds.java
+++ b/src/main/java/com/palantir/gradle/versions/GradleWorkarounds.java
@@ -113,11 +113,15 @@ final class GradleWorkarounds {
     }
 
     /**
-     * Work around gradle < 5.3.rc-1 not adding an AttributeFactory to {@link ProjectDependency} with configuration,
-     * and {@link ExternalDependency#copy()} not configuring an AttributeFactory and ALSO not immutably copying the
-     * {@link AttributeContainer}.
-     *
-     * PR to fix upstream: https://github.com/gradle/gradle/pull/9653
+     * Work around the following issues with {@link ModuleDependency} attributes.
+     * <ul>
+     *     <li>Gradle not adding an AttributeFactory to {@link ProjectDependency} with configuration, fixed in
+     *     5.3-rc-1</li>
+     *     <li>{@link ExternalDependency#copy()} not configuring an AttributeFactory and ALSO not immutably copying the
+     *      {@link AttributeContainer}, fixed in 5.6-rc-1.
+     *      <p>
+     *      See https://github.com/gradle/gradle/pull/9653</li>
+     * </ul>
      */
     static <T extends ModuleDependency> T fixAttributesOfModuleDependency(
             ObjectFactory objectFactory, T dependency) {

--- a/src/main/java/com/palantir/gradle/versions/GradleWorkarounds.java
+++ b/src/main/java/com/palantir/gradle/versions/GradleWorkarounds.java
@@ -116,9 +116,17 @@ final class GradleWorkarounds {
      * Work around gradle < 5.3.rc-1 not adding an AttributeFactory to {@link ProjectDependency} with configuration,
      * and {@link ExternalDependency#copy()} not configuring an AttributeFactory and ALSO not immutably copying the
      * {@link AttributeContainer}.
+     *
+     * PR to fix upstream: https://github.com/gradle/gradle/pull/9653
      */
     static <T extends ModuleDependency> T fixAttributesOfModuleDependency(
             ObjectFactory objectFactory, T dependency) {
+        if (GradleVersion.current().compareTo(GradleVersion.version("5.6-rc-1")) >= 0
+                // Merged on 2019-06-12 so next nightly should be good
+                || GradleVersion.current().compareTo(GradleVersion.version("5.6-20190613000000+0000")) >= 0) {
+            return dependency;
+        }
+        log.debug("Fixing attributes of module dependency to work around gradle#9653: {}", dependency.toString());
         org.gradle.api.internal.artifacts.dependencies.AbstractModuleDependency abstractModuleDependency =
                 (org.gradle.api.internal.artifacts.dependencies.AbstractModuleDependency) dependency;
         org.gradle.api.internal.attributes.ImmutableAttributesFactory factory =


### PR DESCRIPTION
## Before this PR
We added a workaround in #141, but the fix for that has already merged in gradle:
https://github.com/gradle/gradle/pull/9653

## After this PR
==COMMIT_MSG==
Stop applying fixAttributesOfModuleDependency workaround if gradle version is new enough.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

