### PR TITLE
bump gradle to a stable version, bump git-version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id 'com.palantir.consistent-versions' version '1.11.2'
     id 'org.inferred.processors' version '3.1.0'
     id 'com.palantir.baseline' version '0.64.0'
-    id 'com.palantir.git-version' version '0.7.3'
+    id 'com.palantir.git-version' version '0.11.0'
 }
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-5.6-20190522000044+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Before this PR
baseline and latest gradle wrapper excavator checks need to be applied together as it currently stands, so neither of them works right now.

## After this PR
==COMMIT_MSG==
Bumping gradle and git-version to unblock the baseline excavator (see run `blogr4j925fpcefkvuqg`).
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

