### PR TITLE
Fix broken poms

### DIFF
--- a/changelog/@unreleased/pr-218.v2.yml
+++ b/changelog/@unreleased/pr-218.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix missing versions in POMs of MavenPublications.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/218

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -19,9 +19,6 @@ package com.palantir.gradle.versions;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.publish.PublishingExtension;
-import org.gradle.api.publish.VariantVersionMappingStrategy;
-import org.gradle.api.publish.maven.MavenPublication;
 
 public class ConsistentVersionsPlugin implements Plugin<Project> {
     @Override
@@ -38,20 +35,6 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
                 proj.getPluginManager().apply(FixLegacyJavaConfigurationsPlugin.class);
             });
         });
-
-        // This is to ensure that we're not producing broken POMs due to missing versions
-        project.allprojects(ConsistentVersionsPlugin::configureResolvedVersionsWithVersionMapping);
     }
 
-
-    private static void configureResolvedVersionsWithVersionMapping(Project project) {
-        project
-                .getExtensions()
-                .getByType(PublishingExtension.class)
-                .getPublications()
-                .withType(MavenPublication.class)
-                .configureEach(publication -> publication.versionMapping(mapping -> {
-                    mapping.allVariants(VariantVersionMappingStrategy::fromResolutionResult);
-                }));
-    }
 }

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -19,6 +19,9 @@ package com.palantir.gradle.versions;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.VariantVersionMappingStrategy;
+import org.gradle.api.publish.maven.MavenPublication;
 
 public class ConsistentVersionsPlugin implements Plugin<Project> {
     @Override
@@ -35,6 +38,20 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
                 proj.getPluginManager().apply(FixLegacyJavaConfigurationsPlugin.class);
             });
         });
+
+        // This is to ensure that we're not producing broken POMs due to missing versions
+        project.allprojects(ConsistentVersionsPlugin::configureResolvedVersionsWithVersionMapping);
     }
 
+
+    private static void configureResolvedVersionsWithVersionMapping(Project project) {
+        project
+                .getExtensions()
+                .getByType(PublishingExtension.class)
+                .getPublications()
+                .withType(MavenPublication.class)
+                .configureEach(publication -> publication.versionMapping(mapping -> {
+                    mapping.allVariants(VariantVersionMappingStrategy::fromResolutionResult);
+                }));
+    }
 }

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -251,13 +251,15 @@ public class VersionsPropsPlugin implements Plugin<Project> {
     }
 
     private static void configureResolvedVersionsWithVersionMapping(Project project) {
-        project
-                .getExtensions()
-                .getByType(PublishingExtension.class)
-                .getPublications()
-                .withType(MavenPublication.class)
-                .configureEach(publication -> publication.versionMapping(mapping -> {
-                    mapping.allVariants(VariantVersionMappingStrategy::fromResolutionResult);
-                }));
+        project.getPluginManager().withPlugin("maven-publish", plugin -> {
+            project
+                    .getExtensions()
+                    .getByType(PublishingExtension.class)
+                    .getPublications()
+                    .withType(MavenPublication.class)
+                    .configureEach(publication -> publication.versionMapping(mapping -> {
+                        mapping.allVariants(VariantVersionMappingStrategy::fromResolutionResult);
+                    }));
+        });
     }
 }

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -40,6 +40,9 @@ import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.VariantVersionMappingStrategy;
+import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.util.GradleVersion;
 
 public class VersionsPropsPlugin implements Plugin<Project> {
@@ -88,6 +91,9 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         project.getDependencies()
                 .getComponents()
                 .all(component -> tryAssignComponentToPlatform(versionsProps, component));
+
+        // This is to ensure that we're not producing broken POMs due to missing versions
+        configureResolvedVersionsWithVersionMapping(project);
     }
 
     private static void applyToRootProject(Project project) {
@@ -242,5 +248,16 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                 GradleVersion.current().compareTo(MINIMUM_GRADLE_VERSION) >= 0,
                 "This plugin requires gradle >= %s",
                 MINIMUM_GRADLE_VERSION);
+    }
+
+    private static void configureResolvedVersionsWithVersionMapping(Project project) {
+        project
+                .getExtensions()
+                .getByType(PublishingExtension.class)
+                .getPublications()
+                .withType(MavenPublication.class)
+                .configureEach(publication -> publication.versionMapping(mapping -> {
+                    mapping.allVariants(VariantVersionMappingStrategy::fromResolutionResult);
+                }));
     }
 }

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -141,6 +141,13 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
             dependencies {
                 rootConfiguration platform('org:platform')
             }
+            publishing {
+                publications {
+                    main(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
         """.stripIndent())
 
         expect:

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -141,18 +141,6 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
             dependencies {
                 rootConfiguration platform('org:platform')
             }
-            publishing {
-                publications {
-                    main(MavenPublication) {
-                        from components.java
-                        versionMapping {
-                            allVariants {
-                                fromResolutionResult()
-                            }
-                        }
-                    }
-                }
-            }
         """.stripIndent())
 
         expect:


### PR DESCRIPTION
## Before this PR
A regression in 1.12.0 (#193) made it so that it was necessary to configure `versionMapping` for publications or else you'd get missing versions in the POM *for imported BOMs*.

## After this PR
==COMMIT_MSG==
Fix imported BOMs missing versions in POMs of MavenPublications, which resulted in the POMs being considered broken.

e.g.
```diff
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>org.apache.spark</groupId>
        <artifactId>spark-dist_2.11-hadoop-palantir-bom</artifactId>
+       <version>3.0.0-palantir.39</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
```
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

