### PR TITLE
Move gradle plugins to buildscript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.12.1'
         classpath 'com.palantir.baseline:gradle-baseline-java:2.1.1'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.2'
-        classpath 'org.inferred:processors:3.1.0'
+        classpath 'gradle.plugin.org.inferred:gradle-processors:3.1.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,14 +43,6 @@ apply from: "$rootDir/gradle/publish-jar.gradle"
 group 'com.palantir.gradle.consistentversions'
 version gitVersion()
 
-apply plugin: 'java-gradle-plugin'
-apply plugin: 'groovy'
-apply plugin: 'com.palantir.baseline'
-apply plugin: 'com.palantir.consistent-versions'
-apply plugin: 'com.palantir.git-version'
-apply plugin: 'org.inferred.processors'
-apply from: "$rootDir/gradle/publish-jar.gradle"
-
 sourceCompatibility = 1.8
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -13,14 +13,14 @@ buildscript {
         classpath 'com.netflix.nebula:nebula-publishing-plugin:13.3.0'
         classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.12.1'
         classpath 'com.palantir.baseline:gradle-baseline-java:2.1.1'
+        classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.2'
+        classpath 'org.inferred:processors:3.1.0'
     }
 }
 
 plugins {
     id 'com.jfrog.bintray' version '1.8.4' apply false
     id 'com.gradle.plugin-publish' version '0.10.1'
-    id 'org.inferred.processors' version '3.1.0'
-    id 'com.palantir.git-version' version '0.12.2'￿
 }
 
 repositories {
@@ -37,6 +37,8 @@ apply plugin: 'java-gradle-plugin'
 apply plugin: 'groovy'
 apply plugin: 'com.palantir.baseline'
 apply plugin: 'com.palantir.consistent-versions'
+apply plugin: 'com.palantir.git-version'
+apply plugin: 'org.inferred.processors'
 apply from: "$rootDir/gradle/publish-jar.gradle"
 
 sourceCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,15 @@ repositories {
     }
 }
 
+
+apply plugin: 'java-gradle-plugin'
+apply plugin: 'groovy'
+apply plugin: 'com.palantir.baseline'
+apply plugin: 'com.palantir.consistent-versions'
+apply plugin: 'com.palantir.git-version'
+apply plugin: 'org.inferred.processors'
+apply from: "$rootDir/gradle/publish-jar.gradle"
+
 group 'com.palantir.gradle.consistentversions'
 version gitVersion()
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,11 @@ buildscript {
         classpath 'com.palantir.baseline:gradle-baseline-java:2.1.1'
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.2'
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.1.0'
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
     }
 }
 
 plugins {
-    id 'com.jfrog.bintray' version '1.8.4' apply false
     id 'com.gradle.plugin-publish' version '0.10.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,16 +11,16 @@ buildscript {
 
     dependencies {
         classpath 'com.netflix.nebula:nebula-publishing-plugin:13.3.0'
+        classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:1.12.1'
+        classpath 'com.palantir.baseline:gradle-baseline-java:2.1.1'
     }
 }
 
 plugins {
     id 'com.jfrog.bintray' version '1.8.4' apply false
     id 'com.gradle.plugin-publish' version '0.10.1'
-    id 'com.palantir.consistent-versions' version '1.12.1'
     id 'org.inferred.processors' version '3.1.0'
-    id 'com.palantir.baseline' version '2.1.1'
-    id 'com.palantir.git-version' version '0.12.2'
+    id 'com.palantir.git-version' version '0.12.2'￿
 }
 
 repositories {
@@ -35,6 +35,8 @@ version gitVersion()
 
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'groovy'
+apply plugin: 'com.palantir.baseline'
+apply plugin: 'com.palantir.consistent-versions'
 apply from: "$rootDir/gradle/publish-jar.gradle"
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
## Before this PR
Plugins defined in plugins DSL make it hard to automatically track adoption of plugin jars as the connection between a plugin and the jar where it is defined is indirect.

## After this PR
==COMMIT_MSG==
Move gradle plugins to buildscript so the actual jars used can be tracked
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->