### PR TITLE
Fix: Don't fail if excluded configuration is resolved early

### DIFF
--- a/changelog/@unreleased/pr-237.v2.yml
+++ b/changelog/@unreleased/pr-237.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix regression where we were failing if an excluded configuration is
+    resolved early.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/237

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -16,11 +16,13 @@
 
 package com.palantir.gradle.versions;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
@@ -42,10 +44,6 @@ import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.VariantVersionMappingStrategy;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.util.GradleVersion;
-
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 
 public class VersionsPropsPlugin implements Plugin<Project> {
     private static final Logger log = Logging.getLogger(VersionsPropsPlugin.class);

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -16,13 +16,11 @@
 
 package com.palantir.gradle.versions;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
@@ -44,6 +42,10 @@ import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.VariantVersionMappingStrategy;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.util.GradleVersion;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class VersionsPropsPlugin implements Plugin<Project> {
     private static final Logger log = Logging.getLogger(VersionsPropsPlugin.class);
@@ -147,21 +149,21 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             }
 
             conf.extendsFrom(rootConfiguration);
-        });
 
-        // We must allow unifiedClasspath to be resolved at configuration-time.
-        if (VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME.equals(conf.getName())) {
-            return;
-        }
-
-        // Add fail-safe error reporting
-        conf.getIncoming().beforeResolve(resolvableDependencies -> {
-            if (GradleWorkarounds.isConfiguring(subproject.getState())) {
-                throw new GradleException(String.format("Not allowed to resolve %s at "
-                        + "configuration time (https://guides.gradle.org/performance/"
-                        + "#don_t_resolve_dependencies_at_configuration_time). Please upgrade your "
-                        + "plugins and double-check your gradle scripts (see stacktrace)", conf));
+            // We must allow unifiedClasspath to be resolved at configuration-time.
+            if (VersionsLockPlugin.UNIFIED_CLASSPATH_CONFIGURATION_NAME.equals(conf.getName())) {
+                return;
             }
+
+            // Add fail-safe error reporting
+            conf.getIncoming().beforeResolve(resolvableDependencies -> {
+                if (GradleWorkarounds.isConfiguring(subproject.getState())) {
+                    throw new GradleException(String.format("Not allowed to resolve %s at "
+                            + "configuration time (https://guides.gradle.org/performance/"
+                            + "#don_t_resolve_dependencies_at_configuration_time). Please upgrade your "
+                            + "plugins and double-check your gradle scripts (see stacktrace)", conf));
+                }
+            });
         });
     }
 

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -207,6 +207,24 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
         e.output.contains("Not allowed to resolve")
     }
 
+    def "does not throw if excluded configuration is resolved early"() {
+        buildFile << '''
+            configurations { foo }
+            
+            versionRecommendations {
+                excludeConfigurations 'foo'
+            }
+            
+            afterEvaluate {
+                configurations.foo.resolve()
+            }
+        '''
+        file('versions.props') << ''
+
+        expect:
+        runTasks()
+    }
+
     def "creates rootConfiguration even if versions props file missing"() {
         buildFile << """
             dependencies {


### PR DESCRIPTION
## Before this PR

There is a regression in 1.11 which occurs when using the `nebula.dependency-recommender` plugin.
It will attempt to resolve the `nebulaRecommenderBom` configuration early, which will then fail.

```
Caused by: org.gradle.api.GradleException: Not allowed to resolve configuration ':nebulaRecommenderBom' at configuration time (https://guides.gradle.org/performance/#don_t_resolve_dependencies_at_configuration_time). Please upgrade your plugins and double-check your gradle scripts (see stacktrace)
        at com.palantir.gradle.versions.VersionsPropsPlugin.lambda$setupConfiguration$7(VersionsPropsPlugin.java:161)
```

## After this PR
==COMMIT_MSG==
Fix regression where we were failing if an excluded configuration is resolved early.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

