### PR TITLE
Fix: copying BOM dependencies from rootConfiguration onto published configuration should not fail

### DIFF
--- a/changelog/@unreleased/pr-243.v2.yml
+++ b/changelog/@unreleased/pr-243.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    Fixes regression introduced in 1.12.0 where you might get a gradle error like the following:
+
+    `Cannot change dependencies of configuration ':foo:runtimeElements' after it has been included in dependency resolution.`
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/243

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -109,8 +109,9 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             return;
         }
 
-        // We must do this addAllLater as soon as possible, otherwise conf.getDependencies() could get realized
-        // early by some other plugin and then we can't modify it anymore.
+        // We must do this addAllLater as soon as possible, otherwise 'conf' could get observed early
+        // by some other configuration that depends on it being resolved, and then we can't modify it anymore.
+        // This can happen if some other configuration depends on 'conf' *intransitively*.
         // These configurations can never be excluded anyway so we don't need the laziness.
         if (JAVA_PUBLISHED_CONFIGURATION_NAMES.contains(conf.getName())) {
             log.debug("Only configuring BOM dependencies on published java configuration: {}", conf);

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -72,13 +72,6 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                 });
 
         project.getConfigurations().configureEach(conf -> {
-            if (conf.getName().equals(ROOT_CONFIGURATION_NAME)) {
-                // We only expect 'platform' dependencies to be declared in rootConfiguration.
-                // This injects missing versions, in case the version comes from a *-dependency in versions.props.
-                // For rootConfiguration, unlike other configurations, this is the only customization necessary.
-                conf.withDependencies(deps -> provideVersionsFromStarDependencies(versionsProps, deps));
-                return;
-            }
             setupConfiguration(project, extension, rootConfiguration.get(), versionsProps, conf);
         });
 
@@ -108,6 +101,23 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             Configuration rootConfiguration,
             VersionsProps versionsProps,
             Configuration conf) {
+        // We only expect 'platform' dependencies to be declared in rootConfiguration.
+        // This injects missing versions, in case the version comes from a *-dependency in versions.props.
+        // For rootConfiguration, unlike other configurations, this is the only customization necessary.
+        if (conf.getName().equals(ROOT_CONFIGURATION_NAME)) {
+            conf.withDependencies(deps -> provideVersionsFromStarDependencies(versionsProps, deps));
+            return;
+        }
+
+        // We must do this addAllLater as soon as possible, otherwise conf.getDependencies() could get realized
+        // early by some other plugin and then we can't modify it anymore.
+        // These configurations can never be excluded anyway so we don't need the laziness.
+        if (JAVA_PUBLISHED_CONFIGURATION_NAMES.contains(conf.getName())) {
+            log.debug("Only configuring BOM dependencies on published java configuration: {}", conf);
+            conf.getDependencies().addAllLater(extractPlatformDependencies(subproject, rootConfiguration));
+            return;
+        }
+
         // Must do all this in a withDependencies block so that it's run lazily, so that
         // `extension.shouldExcludeConfiguration` isn't queried too early (before the user had the change to configure).
         // However, we must not make this lazy using an afterEvaluate.
@@ -126,12 +136,6 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             }
             if (extension.shouldExcludeConfiguration(conf.getName())) {
                 log.debug("Not configuring {} because it's excluded", conf);
-                return;
-            }
-
-            if (JAVA_PUBLISHED_CONFIGURATION_NAMES.contains(conf.getName())) {
-                log.debug("Only configuring BOM dependencies on published java configuration: {}", conf);
-                deps.addAllLater(extractPlatformDependencies(subproject, rootConfiguration));
                 return;
             }
 

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -109,15 +109,6 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             return;
         }
 
-        // We must do this addAllLater as soon as possible, otherwise conf.getDependencies() could get realized
-        // early by some other plugin and then we can't modify it anymore.
-        // These configurations can never be excluded anyway so we don't need the laziness.
-        if (JAVA_PUBLISHED_CONFIGURATION_NAMES.contains(conf.getName())) {
-            log.debug("Only configuring BOM dependencies on published java configuration: {}", conf);
-            conf.getDependencies().addAllLater(extractPlatformDependencies(subproject, rootConfiguration));
-            return;
-        }
-
         // Must do all this in a withDependencies block so that it's run lazily, so that
         // `extension.shouldExcludeConfiguration` isn't queried too early (before the user had the change to configure).
         // However, we must not make this lazy using an afterEvaluate.
@@ -136,6 +127,15 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             }
             if (extension.shouldExcludeConfiguration(conf.getName())) {
                 log.debug("Not configuring {} because it's excluded", conf);
+                return;
+            }
+
+            // We must do this addAllLater as soon as possible, otherwise conf.getDependencies() could get realized
+            // early by some other plugin and then we can't modify it anymore.
+            // These configurations can never be excluded anyway so we don't need the laziness.
+            if (JAVA_PUBLISHED_CONFIGURATION_NAMES.contains(conf.getName())) {
+                log.debug("Only configuring BOM dependencies on published java configuration: {}", conf);
+                conf.getDependencies().addAllLater(extractPlatformDependencies(subproject, rootConfiguration));
                 return;
             }
 

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -109,6 +109,15 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             return;
         }
 
+        // We must do this addAllLater as soon as possible, otherwise conf.getDependencies() could get realized
+        // early by some other plugin and then we can't modify it anymore.
+        // These configurations can never be excluded anyway so we don't need the laziness.
+        if (JAVA_PUBLISHED_CONFIGURATION_NAMES.contains(conf.getName())) {
+            log.debug("Only configuring BOM dependencies on published java configuration: {}", conf);
+            conf.getDependencies().addAllLater(extractPlatformDependencies(subproject, rootConfiguration));
+            return;
+        }
+
         // Must do all this in a withDependencies block so that it's run lazily, so that
         // `extension.shouldExcludeConfiguration` isn't queried too early (before the user had the change to configure).
         // However, we must not make this lazy using an afterEvaluate.
@@ -127,15 +136,6 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             }
             if (extension.shouldExcludeConfiguration(conf.getName())) {
                 log.debug("Not configuring {} because it's excluded", conf);
-                return;
-            }
-
-            // We must do this addAllLater as soon as possible, otherwise conf.getDependencies() could get realized
-            // early by some other plugin and then we can't modify it anymore.
-            // These configurations can never be excluded anyway so we don't need the laziness.
-            if (JAVA_PUBLISHED_CONFIGURATION_NAMES.contains(conf.getName())) {
-                log.debug("Only configuring BOM dependencies on published java configuration: {}", conf);
-                conf.getDependencies().addAllLater(extractPlatformDependencies(subproject, rootConfiguration));
                 return;
             }
 


### PR DESCRIPTION
## Before this PR

We were attempting to add BOM dependencies to published configurations very late, in the `withDependencies` block. This was actually not necessary since we add them lazily anyway, via `addAllLater`.

Glossary:
* **resolving** a configuration - figuring out its entire (usually transitive) dependency graph
* **realizing** a configuration - lazy dependencies/constraints/exclusions being evaluated and set in stone - note that this is a prerequisite to but not the same as resolving a configuration
* **observing** a configuration - happens when another configuration is resolved, and it either has a dependency onto / extends this configuration

Sadly, doing it this way meant that if any such published configuration (like `runtimeElements`) is **observed** before being **realized**, then we'd be trying to add new dependencies too late and we'd get an error. This can happen if the other configuration that triggers this one to be observed has an intransitive dependency.

This could happen in the following scenario:

* Project A has two configurations that depend on B.
* One depends on B intransitively, while the other transitively (normally)
* Project B declares a platform dependency on its `rootConfiguration` configuration
* We have some tasks that trigger the resolution of these two configurations in A. We can call them `resolveIntransitively` and `resolveTransitively`.
`resolveIntransitively` runs first.

Steps to repro:

2. `:A:resolveIntransitively` runs. Due to the intransitive nature of the dependency, lazy dependencies/constraints/excludes from `:B:runtimeElements` are *not realized* (normally they would be)
3. `A` depends on `B` so this resolution marks `conf :B:runtimeElements` as observed, or in other words "included in dependency resolution"
3. `:A:resolveTransitively` runs, triggering the `:B:runtimeElements` to be *realized*
4. The withDependencies action of `conf :B:runtimeElements` runs, attempting to add the BOM dependency to this configuration
https://github.com/palantir/gradle-consistent-versions/blob/0b9a23746a8c87d8c6ea0807fc3545973d997195/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java#L133
5. This then fails with 
    
```
Cannot change dependencies of configuration ':B:runtimeElements' after it has been included in dependency resolution.
```

This is a regression introduced by #193 in 1.12.0.

Fixes #221.

## After this PR
==COMMIT_MSG==
Fixes regression introduced in 1.12.0 where you might get a gradle error like the following:

`Cannot change dependencies of configuration ':foo:runtimeElements' after it has been included in dependency resolution.`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

