### PR TITLE
Gradle 6.0 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ apply plugin: 'org.inferred.processors'
 apply from: "$rootDir/gradle/publish-jar.gradle"
 
 group 'com.palantir.gradle.consistentversions'
-version gitVersion()
+version System.env.CIRCLE_TAG ?: gitVersion()
 
 sourceCompatibility = 1.8
 

--- a/changelog/@unreleased/pr-343.v2.yml
+++ b/changelog/@unreleased/pr-343.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`gradle-consistent-versions` now supports Gradle 6.0. The minimum
+    required Gradle version has been raised to 5.3'
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/343

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -353,7 +353,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
         project.getConfigurations().register(CONSISTENT_VERSIONS_PRODUCTION, conf -> {
             conf.setDescription(
-                    "Outgoing configuration for production dependencies meant to be used by " + "consistent-versions");
+                    "Outgoing configuration for production dependencies meant to be used by consistent-versions");
             conf.setVisible(false); // needn't be visible from other projects
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);
@@ -363,7 +363,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
         project.getConfigurations().register(CONSISTENT_VERSIONS_TEST, conf -> {
             conf.setDescription(
-                    "Outgoing configuration for test dependencies meant to be used by " + "consistent-versions");
+                    "Outgoing configuration for test dependencies meant to be used by consistent-versions");
             conf.setVisible(false); // needn't be visible from other projects
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -391,7 +391,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 "path", project.getPath(), "configuration", toConfiguration.getName()));
     }
 
-    /** Create a dependency to {@code toConfiguration}, where the latter should exist in the given {@code project}. */
+    /** Create a dependency requiring capabilities for the listed scope */
     private static Dependency createDependencyOnProjectWithScope(Project project, GcvScope scope) {
         ProjectDependency projectDependency = (ProjectDependency) project.getDependencies().create(project);
         projectDependency.capabilities(moduleDependencyCapabilitiesHandler ->

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -391,7 +391,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 "path", project.getPath(), "configuration", toConfiguration.getName()));
     }
 
-    /** Create a dependency requiring capabilities for the listed scope */
+    /** Create a dependency requiring capabilities for the listed scope. */
     private static Dependency createDependencyOnProjectWithScope(Project project, GcvScope scope) {
         ProjectDependency projectDependency = (ProjectDependency) project.getDependencies().create(project);
         projectDependency.capabilities(moduleDependencyCapabilitiesHandler ->

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -601,6 +601,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 GradleWorkarounds.fixAttributesOfModuleDependency(projectDep.getObjects(), externalDep);
                 externalDep.attributes(attr -> attr.attribute(GCV_SCOPE_ATTRIBUTE, scope));
             });
+            // To avoid capability based conflict detection between all these copied configurations, we give each
+            // of them a totally random capability
             copiedConf.getOutgoing().capability(String.format("gcv:%s:0", UUID.randomUUID().toString()));
 
             projectDep.getConfigurations().add(copiedConf);

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -351,27 +351,25 @@ public class VersionsLockPlugin implements Plugin<Project> {
             conf.getAttributes().attribute(GCV_USAGE_ATTRIBUTE, GcvUsage.GCV_SOURCE);
         });
 
-        project.getConfigurations()
-                .register(CONSISTENT_VERSIONS_PRODUCTION, conf -> {
-                    conf.setDescription("Outgoing configuration for production dependencies meant to be used by "
-                            + "consistent-versions");
-                    conf.setVisible(false); // needn't be visible from other projects
-                    conf.setCanBeConsumed(true);
-                    conf.setCanBeResolved(false);
-                    conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
-                    conf.getOutgoing().capability(capabilityFor(project, GcvScope.PRODUCTION));
-                });
+        project.getConfigurations().register(CONSISTENT_VERSIONS_PRODUCTION, conf -> {
+            conf.setDescription(
+                    "Outgoing configuration for production dependencies meant to be used by " + "consistent-versions");
+            conf.setVisible(false); // needn't be visible from other projects
+            conf.setCanBeConsumed(true);
+            conf.setCanBeResolved(false);
+            conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
+            conf.getOutgoing().capability(capabilityFor(project, GcvScope.PRODUCTION));
+        });
 
-        project.getConfigurations()
-                .register(CONSISTENT_VERSIONS_TEST, conf -> {
-                    conf.setDescription("Outgoing configuration for test dependencies meant to be used by "
-                            + "consistent-versions");
-                    conf.setVisible(false); // needn't be visible from other projects
-                    conf.setCanBeConsumed(true);
-                    conf.setCanBeResolved(false);
-                    conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
-                    conf.getOutgoing().capability(capabilityFor(project, GcvScope.TEST));
-                });
+        project.getConfigurations().register(CONSISTENT_VERSIONS_TEST, conf -> {
+            conf.setDescription(
+                    "Outgoing configuration for test dependencies meant to be used by " + "consistent-versions");
+            conf.setVisible(false); // needn't be visible from other projects
+            conf.setCanBeConsumed(true);
+            conf.setCanBeResolved(false);
+            conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
+            conf.getOutgoing().capability(capabilityFor(project, GcvScope.TEST));
+        });
 
         unifiedClasspath.getDependencies().add(createConfigurationDependencyWithScope(project, GcvScope.PRODUCTION));
         unifiedClasspath.getDependencies().add(createConfigurationDependencyWithScope(project, GcvScope.TEST));

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -109,7 +109,7 @@ import org.immutables.value.Value;
 
 public class VersionsLockPlugin implements Plugin<Project> {
     private static final Logger log = Logging.getLogger(VersionsLockPlugin.class);
-    private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("5.1");
+    static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("5.3");
 
     /** Root project configuration that collects all the dependencies from each project. */
     static final String UNIFIED_CLASSPATH_CONFIGURATION_NAME = "unifiedClasspath";

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -52,7 +52,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -594,9 +593,11 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 GradleWorkarounds.fixAttributesOfModuleDependency(projectDep.getObjects(), externalDep);
                 externalDep.attributes(attr -> attr.attribute(GCV_SCOPE_ATTRIBUTE, scope));
             });
-            // To avoid capability based conflict detection between all these copied configurations, we give each
-            // of them a totally random capability
-            copiedConf.getOutgoing().capability(String.format("gcv:%s:0", UUID.randomUUID().toString()));
+            // To avoid capability based conflict detection between all these copied configurations (where they
+            // conflict as each has no capabilities), we give each of them a capability
+            copiedConf.getOutgoing().capability(String.format(
+                    "gcv:%s-%s-%s-%s:extra",
+                    projectDep.getGroup(), projectDep.getName(), projectDep.getVersion(), copiedConf.getName()));
 
             projectDep.getConfigurations().add(copiedConf);
 

--- a/src/main/java/com/palantir/gradle/versions/VersionsProps.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsProps.java
@@ -67,7 +67,7 @@ public final class VersionsProps {
                 fuzzyResolver.exactMatches().stream().map(key -> key + ":" + versions.get(key)).map(handler::create),
                 patternToPlatform.entrySet().stream()
                         .map(entry -> entry.getValue() + ":" + versions.get(entry.getKey()))
-                        .map(handler::platform));
+                        .map(handler::create));
     }
 
     /**

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -16,8 +16,12 @@
 
 package com.palantir.gradle.versions
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import static com.palantir.gradle.versions.GradleTestVersions.GRADLE_VERSIONS
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Unroll
+
+@Unroll
 class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
     static def PLUGIN_NAME = "com.palantir.consistent-versions"
@@ -54,16 +58,25 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
     }
 
-    def 'can write locks'() {
+    def '#gradleVersionNumber: can write locks'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         when:
         runTasks('--write-locks')
 
         then:
         new File(projectDir, "versions.lock").exists()
         runTasks('resolveConfigurations')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'can resolve all configurations like compile with version coming only from versions props'() {
+    def '#gradleVersionNumber: can resolve all configurations like compile with version coming only from versions props'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         file('versions.props') << """
             org.slf4j:slf4j-api:1.7.22
         """.stripIndent()
@@ -81,9 +94,15 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         then:
         // Ensures that configurations like 'compile' are resolved and their dependencies have versions
         runTasks('resolveConfigurations')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "locks are consistent whether or not we do --write-locks for glob-forced direct dependency"() {
+    def "#gradleVersionNumber: locks are consistent whether or not we do --write-locks for glob-forced direct dependency"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << '''
             apply plugin: 'java'
             dependencies {
@@ -97,9 +116,15 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks('resolveConfigurations', '--write-locks')
         runTasks('resolveConfigurations')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "getVersion function works"() {
+    def "#gradleVersionNumber: getVersion function works"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << '''
             apply plugin: 'java'
             dependencies {
@@ -118,9 +143,15 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         expect:
         runTasks('demo').output.contains("demo=1.7.25")
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "getVersion function works even when writing locks"() {
+    def "#gradleVersionNumber: getVersion function works even when writing locks"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << '''
             apply plugin: 'java'
             dependencies {
@@ -136,9 +167,15 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         expect:
         runTasks('demo', '--write-locks').output.contains("demo=1.7.25")
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "virtual platform is respected across projects"() {
+    def "#gradleVersionNumber: virtual platform is respected across projects"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         addSubproject('foo', """
             apply plugin: 'java'
             dependencies {
@@ -168,9 +205,15 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
             test-alignment:module-with-higher-version:1.1 (1 constraints: a6041b2c)
         """.stripIndent()
         file('versions.lock').text == expectedLock
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "star dependencies in the absence of dependency versions"() {
+    def "#gradleVersionNumber: star dependencies in the absence of dependency versions"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         addSubproject('foo', """
             apply plugin: 'java'
             dependencies {
@@ -194,9 +237,15 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         // Ensure that this is a required constraint
         runTasks('why', '--hash', '4105483b').output.contains "projects -> 1.7.25"
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "writeLocks and verifyLocks work in the presence of versions props constraints"() {
+    def "#gradleVersionNumber: writeLocks and verifyLocks work in the presence of versions props constraints"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         generateMavenRepo(
                 "org1:platform:1.0",
                 "org2:platform:1.0",
@@ -248,9 +297,15 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         and: 'Ensure you can verify locks and resolve the actual locked configurations'
         runTasks('verifyLocks', 'resolveLockedConfigurations', 'resolveNonLockedConfiguration')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "versions props contents do not get published as constraints"() {
+    def "#gradleVersionNumber: versions props contents do not get published as constraints"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             allprojects {
                 apply plugin: 'java'
@@ -307,9 +362,15 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
                         dependencies: [logbackDep],
                         dependencyConstraints: [logbackDep, slf4jDep]),
         ] as Set
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "intransitive dependency on published configuration should not break realizing it later"() {
+    def "#gradleVersionNumber: intransitive dependency on published configuration should not break realizing it later"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         addSubproject('source', """
             configurations {
                 transitive
@@ -364,5 +425,8 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         expect:
         runTasks('resolveIntransitively', 'resolveTransitively')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 }

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -19,6 +19,7 @@ package com.palantir.gradle.versions
 import static com.palantir.gradle.versions.GradleTestVersions.GRADLE_VERSIONS
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.gradle.util.GradleVersion
 import spock.lang.Unroll
 
 @Unroll
@@ -332,9 +333,11 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
             should:not-publish = 1.0
         """.stripIndent()
 
-        settingsFile << """
-            enableFeaturePreview('GRADLE_METADATA')
-        """.stripIndent()
+        if (GradleVersion.version(gradleVersionNumber) < GradleVersion.version("6.0")) {
+            settingsFile << """
+                enableFeaturePreview('GRADLE_METADATA')
+            """.stripIndent()
+        }
 
         when:
         runTasks('--write-locks', 'generateMetadataFileForMavenPublication')

--- a/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
+++ b/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
@@ -22,5 +22,6 @@ import java.util.List;
 public final class GradleTestVersions {
     private GradleTestVersions() {}
 
-    public static final List<String> GRADLE_VERSIONS = ImmutableList.of("5.6.3", "6.0.1");
+    public static final List<String> GRADLE_VERSIONS =
+            ImmutableList.of(VersionsLockPlugin.MINIMUM_GRADLE_VERSION.getVersion(), "6.0.1");
 }

--- a/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
+++ b/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+public final class GradleTestVersions {
+    private GradleTestVersions() { }
+
+    public static final List<String> GRADLE_VERSIONS = ImmutableList.of("5.6.3", "6.0.1");
+}

--- a/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
+++ b/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 public final class GradleTestVersions {
-    private GradleTestVersions() { }
+    private GradleTestVersions() {}
 
     public static final List<String> GRADLE_VERSIONS = ImmutableList.of("5.6.3", "6.0.1");
 }

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -16,12 +16,16 @@
 
 package com.palantir.gradle.versions
 
+import static com.palantir.gradle.versions.GradleTestVersions.GRADLE_VERSIONS
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import nebula.test.dependencies.DependencyGraph
 import nebula.test.dependencies.GradleDependencyGenerator
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Unroll
 
+@Unroll
 class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
     static def PLUGIN_NAME = "com.palantir.versions-lock"
@@ -58,10 +62,16 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         """
     }
 
-    def 'can write locks'() {
+    def '#gradleVersionNumber: can write locks'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+        
         expect:
         runTasks('--write-locks')
         new File(projectDir, "versions.lock").exists()
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
     private def standardSetup() {
@@ -110,8 +120,9 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         '''.stripIndent())
     }
 
-    def 'cannot resolve without a root lock file'() {
+    def '#gradleVersionNumber: cannot resolve without a root lock file'() {
         setup:
+        gradleVersion = gradleVersionNumber
         standardSetup()
 
         expect:
@@ -119,18 +130,26 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         result.output.readLines().any {
             it.matches ".*Root lock file '([^']+)' doesn't exist, please run.*"
         }
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'can resolve without a root lock file if lock file is ignored'() {
+    def '#gradleVersionNumber: can resolve without a root lock file if lock file is ignored'() {
         setup:
+        gradleVersion = gradleVersionNumber
         standardSetup()
 
         expect:
         runTasks('resolveConfigurations', '-PignoreLockFile')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'global nebula recommendations are superseded by transitive'() {
+    def '#gradleVersionNumber: global nebula recommendations are superseded by transitive'() {
         setup:
+        gradleVersion = gradleVersionNumber
         buildFile << """
             allprojects {
                 apply plugin: 'nebula.dependency-recommender'
@@ -178,11 +197,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         and: "I can resolve"
         runTasks('resolveConfigurations')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'consolidates subproject dependencies'() {
+    def '#gradleVersionNumber: consolidates subproject dependencies'() {
         def expectedError = "Locked by versions.lock"
         setup:
+        gradleVersion = gradleVersionNumber
         standardSetup()
         buildFile << '''
             subprojects {
@@ -229,9 +252,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         then: "Resolution fails"
         def error = runTasksAndFail(':baz:resolveConfigurations')
         error.output.contains(expectedError)
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'works on just root project'() {
+    def '#gradleVersionNumber: works on just root project'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << '''
             apply plugin: 'java'
             dependencies {
@@ -244,11 +273,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         def lines = file('versions.lock').readLines()
         lines.contains('ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)')
         lines.contains('org.slf4j:slf4j-api:1.7.25 (1 constraints: 400d4d2a)')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'get a conflict even if no lock files applied'() {
+    def '#gradleVersionNumber: get a conflict even if no lock files applied'() {
         def expectedError = "Locked by versions.lock"
         setup:
+        gradleVersion = gradleVersionNumber
         standardSetup()
 
         when: "I write locks"
@@ -265,9 +298,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         then: "Resolution fails"
         incompatible.output.contains(expectedError)
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'fails fast when subproject that is depended on has same name as root project'() {
+    def '#gradleVersionNumber: fails fast when subproject that is depended on has same name as root project'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         def expectedError = "This plugin doesn't work if the root project shares both group and name with a subproject"
         buildFile << """
             allprojects {
@@ -290,9 +329,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         def error = runTasksAndFail()
         error.output.contains(expectedError)
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'fails fast when multiple subprojects share the same coordinate'() {
+    def '#gradleVersionNumber: fails fast when multiple subprojects share the same coordinate'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         def expectedError = "All subprojects must have unique \$group:\$name"
         buildFile << """
             allprojects {
@@ -308,9 +353,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         def error = runTasksAndFail()
         error.output.contains(expectedError)
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "detects failOnVersionConflict on locked configuration"() {
+    def "#gradleVersionNumber: detects failOnVersionConflict on locked configuration"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             apply plugin: 'java'    
             configurations.compileClasspath.resolutionStrategy.failOnVersionConflict()
@@ -320,9 +371,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         def failure = runTasksAndFail()
         failure.output.contains('Must not use failOnVersionConflict')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "ignores failOnVersionConflict on non-locked configuration"() {
+    def "#gradleVersionNumber: ignores failOnVersionConflict on non-locked configuration"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             apply plugin: 'java'    
             configurations {
@@ -335,9 +392,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         expect:
         runTasks()
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'fails if new dependency added that was not in the lock file'() {
+    def '#gradleVersionNumber: fails if new dependency added that was not in the lock file'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         def expectedError = "Found dependencies that were not in the lock state"
         DependencyGraph dependencyGraph = new DependencyGraph("org:a:1.0", "org:b:1.0")
         GradleDependencyGenerator generator = new GradleDependencyGenerator(dependencyGraph)
@@ -376,9 +439,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         and: 'Can finally write locks once again'
         runTasks('--write-locks')
         runTasks('verifyLocks')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'does not fail if unifiedClasspath is unresolvable'() {
+    def '#gradleVersionNumber: does not fail if unifiedClasspath is unresolvable'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         file('versions.lock') << """\
             org.slf4j:slf4j-api:1.7.11 (0 constraints: 0000000)
         """.stripIndent()
@@ -393,9 +462,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks('dependencies', '--configuration', 'unifiedClasspath')
         runTasks()
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'fails if dependency was removed but still in the lock file'() {
+    def '#gradleVersionNumber: fails if dependency was removed but still in the lock file'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         def expectedError = "Locked dependencies missing from the resolution result"
         DependencyGraph dependencyGraph = new DependencyGraph("org:a:1.0", "org:b:1.0")
         GradleDependencyGenerator generator = new GradleDependencyGenerator(dependencyGraph)
@@ -435,9 +510,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         and: 'Can finally write locks once again'
         runTasks('--write-locks')
         runTasks('verifyLocks')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "why works"() {
+    def "#gradleVersionNumber: why works"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << '''
             apply plugin: 'java'
             dependencies {
@@ -452,9 +533,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         def result = runTasks('why', '--hash', '400d4d2a') // slf4j-api
         result.output.contains('org.slf4j:slf4j-api:1.7.25')
         result.output.contains('ch.qos.logback:logback-classic -> 1.7.25')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def 'does not fail if subproject evaluated later applies base plugin in own build file'() {
+    def '#gradleVersionNumber: does not fail if subproject evaluated later applies base plugin in own build file'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         addSubproject('foo', """
             apply plugin: 'java-library'
             dependencies {
@@ -472,9 +559,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         expect:
         runTasks('--write-locks')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "locks platform"() {
+    def "#gradleVersionNumber: locks platform"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             apply plugin: 'java'
             dependencies {
@@ -490,9 +583,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
                 '# Run ./gradlew --write-locks to regenerate this file',
                 'org:platform:1.0 (1 constraints: a5041a2c)',
         ]
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "verifyLocks is cacheable"() {
+    def "#gradleVersionNumber: verifyLocks is cacheable"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             apply plugin: 'java'
             dependencies {
@@ -508,10 +607,16 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         then: 'verifyLocks is up to date the second time'
         runTasks('verifyLocks').task(':verifyLocks').outcome == TaskOutcome.SUCCESS
         runTasks('verifyLocks').task(':verifyLocks').outcome == TaskOutcome.UP_TO_DATE
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
 
-    def "verifyLocks current lock state does not get poisoned by existing lock file"() {
+    def "#gradleVersionNumber: verifyLocks current lock state does not get poisoned by existing lock file"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             apply plugin: 'java'
             dependencies {
@@ -533,9 +638,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
                  -org.slf4j:slf4j-api:1.7.20 (1 constraints: 3c05433b)
                  +org.slf4j:slf4j-api:1.7.11 (1 constraints: 3c05423b)
             """.stripIndent()
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "excludes from compileOnly do not obscure real dependency"() {
+    def "#gradleVersionNumber: excludes from compileOnly do not obscure real dependency"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             apply plugin: 'java'
             dependencies {
@@ -556,9 +667,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
                 'ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)',
                 'org.slf4j:slf4j-api:1.7.25 (1 constraints: 400d4d2a)',
         ]
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "can resolve configuration dependency"() {
+    def "#gradleVersionNumber: can resolve configuration dependency"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         addSubproject("foo", """
             apply plugin: 'java'
             dependencies {
@@ -591,9 +708,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         expect:
         runTasks('--write-locks', 'classes')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "inter-project normal dependency works"() {
+    def "#gradleVersionNumber: inter-project normal dependency works"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         addSubproject("foo", """
             apply plugin: 'java'
             dependencies {
@@ -607,9 +730,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         expect:
         runTasks('--write-locks', 'classes')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "test dependencies appear in a separate block"() {
+    def "#gradleVersionNumber: test dependencies appear in a separate block"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             apply plugin: 'java'           
             dependencies {
@@ -629,9 +758,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
             org:test-dep-that-logs:1.0 (1 constraints: a5041a2c)
         """.stripIndent()
         file('versions.lock').text == expected
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "locks dependencies from extra source sets that end in test"() {
+    def "#gradleVersionNumber: locks dependencies from extra source sets that end in test"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             apply plugin: 'java'
             sourceSets {
@@ -656,9 +791,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
             org:test-dep-that-logs:1.0 (1 constraints: a5041a2c)
         """.stripIndent()
         file('versions.lock').text == expected
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "versionsLock.testProject() works"() {
+    def "#gradleVersionNumber: versionsLock.testProject() works"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             apply plugin: 'java'
             dependencies {
@@ -677,9 +818,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
             junit:junit:4.10 (1 constraints: d904fd30)
         """.stripIndent()
         file('versions.lock').text == expected
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "constraints on production do not affect scope of test only dependencies"() {
+    def "#gradleVersionNumber: constraints on production do not affect scope of test only dependencies"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             apply plugin: 'java'
             dependencies {
@@ -702,9 +849,15 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
             org.slf4j:slf4j-api:1.7.25 (1 constraints: 400d4d2a)
         """.stripIndent()
         file('versions.lock').text == expected
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "published constraints are derived from filtered lock file"() {
+    def "#gradleVersionNumber: published constraints are derived from filtered lock file"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
         buildFile << """
             allprojects {
                 apply plugin: 'java'
@@ -782,5 +935,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
                         dependencyConstraints: [junitDep]),
         ] as Set
 
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 }

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -23,6 +23,7 @@ import nebula.test.dependencies.DependencyGraph
 import nebula.test.dependencies.GradleDependencyGenerator
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.GradleVersion
 import spock.lang.Unroll
 
 @Unroll
@@ -883,9 +884,11 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
             }
         """.stripIndent())
 
-        settingsFile << """
-            enableFeaturePreview('GRADLE_METADATA')
-        """.stripIndent()
+        if (GradleVersion.version(gradleVersionNumber) < GradleVersion.version("6.0")) {
+            settingsFile << """
+                enableFeaturePreview('GRADLE_METADATA')
+            """.stripIndent()
+        }
 
         runTasks('--write-locks')
 

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -18,10 +18,13 @@ package com.palantir.gradle.versions
 
 import groovy.util.slurpersupport.GPathResult
 import groovy.util.slurpersupport.NodeChildren
+import spock.lang.Unroll
 
+@Unroll
 class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
-
     static def PLUGIN_NAME = "com.palantir.versions-props"
+
+    private static final List<String> GRADLE_VERSIONS = ['5.6.3', '6.0.1']
 
     void setup() {
         File mavenRepo = generateMavenRepo(
@@ -66,8 +69,10 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
     }
 
-    def 'star dependency constraint is injected for direct dependency'() {
+    def '#gradleVersionNumber: star dependency constraint is injected for direct dependency'() {
         setup:
+        gradleVersion = gradleVersionNumber
+
         file("versions.props") << """
             org.slf4j:* = 1.7.24
         """.stripIndent()
@@ -84,6 +89,9 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
 
         file("foo/gradle/dependency-locks/runtimeClasspath.lockfile").text
                 .contains("org.slf4j:slf4j-api:1.7.24")
+
+        where:
+        gradleVersionNumber = GRADLE_VERSIONS
     }
 
     def 'star dependency constraint is not forcefully downgraded for transitive dependency'() {

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -91,7 +91,7 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
                 .contains("org.slf4j:slf4j-api:1.7.24")
 
         where:
-        gradleVersionNumber = GRADLE_VERSIONS
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 
     def 'star dependency constraint is not forcefully downgraded for transitive dependency'() {


### PR DESCRIPTION
## Before this PR
Running GCV on Gradle 6.0 results in this error message:

```
> Failed to apply plugin [class 'com.palantir.gradle.versions.VersionsLockPlugin']
   > Cannot add attributes or capabilities on a dependency that specifies artifacts or configuration information
```

## After this PR
==COMMIT_MSG==
`gradle-consistent-versions` now supports Gradle 6.0. The minimum required Gradle version has been raised to 5.3
==COMMIT_MSG==

## Possible downsides?
Minimum Gradle version needs to be bumped to support usage of capabilities.

