### PR TITLE
add checkUnusedConstraints task

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Direct dependencies are specified in a top level `versions.props` file and then 
     1. versions.props: lower bounds for dependencies
     1. versions.lock: compact representation of your prod classpath
     1. ./gradlew why
+    1. ./gradlew checkUnusedConstraints
     1. getVersion
     1. BOMs
     1. Specifying exact versions
@@ -158,6 +159,10 @@ This is effectively just a more concise version of `dependencyInsight`:
 ```
 ./gradlew  dependencyInsight --configuration unifiedClasspath --dependency jackson-databind
 ```
+
+## ./gradlew checkUnusedConstraints
+`checkUnusedConstraints` prevents unnecessary constraints from accruing in your `versions.props` file. Run 
+`./gradlew checkUnusedConstraints --fix` to automatically remove any unused constraints from your props file.
 
 ### getVersion
 If you want to use the resolved version of some dependency elsewhere in your Gradle files, gradle-consistent-versions offers the `getVersion(group, name, [configuration])` convenience function. For example:

--- a/changelog/@unreleased/pr-365.v2.yml
+++ b/changelog/@unreleased/pr-365.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Add `checkUnusedConstraints` task which will ensure that the set of
+    constraints in the versions.props file is minimal. Calling the task with `--fix`
+    will automatically remove any unnecessary constraints.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/365

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
@@ -37,7 +37,6 @@ import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
@@ -73,10 +72,6 @@ public class CheckUnusedConstraintsTask extends DefaultTask {
 
     @Option(option = "fix", description = "Whether to apply the suggested fix to versions.props")
     public final void setShouldFix(boolean shouldFix) {
-        this.shouldFix.set(shouldFix);
-    }
-
-    final void setShouldFix(Provider<Boolean> shouldFix) {
         this.shouldFix.set(shouldFix);
     }
 

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
@@ -92,10 +92,7 @@ public class CheckUnusedConstraintsTask extends DefaultTask {
 
         // assumes globs are sorted by specificity
         for (FuzzyPatternResolver.Glob glob : versionsProps.getFuzzyResolver().globs()) {
-            Optional<String> matchingArtifact = unmatchedArtifacts.stream().filter(glob::matches).findFirst();
-            if (matchingArtifact.isPresent()) {
-                unmatchedArtifacts.remove(matchingArtifact.get());
-            } else {
+            if (!unmatchedArtifacts.removeIf(glob::matches)) {
                 unusedConstraints.add(glob.getRawPattern());
             }
         }

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
@@ -1,0 +1,163 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolutionResult;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
+
+public class CheckUnusedConstraintsTask extends DefaultTask {
+
+    private final Property<Boolean> shouldFix = getProject().getObjects().property(Boolean.class);
+    private final RegularFileProperty propsFileProperty = getProject().getObjects().fileProperty();
+    private final SetProperty<String> classpath = getProject().getObjects().setProperty(String.class);
+
+    public CheckUnusedConstraintsTask() {
+        shouldFix.set(false);
+        setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
+        setDescription("Ensures all versions in your versions.props correspond to an actual gradle dependency");
+    }
+
+    final void setPropsFile(File propsFile) {
+        this.propsFileProperty.set(propsFile);
+    }
+
+    @Input
+    public final SetProperty<String> getClasspath() {
+        return classpath;
+    }
+
+    @InputFile
+    public final Property<RegularFile> getPropsFile() {
+        return propsFileProperty;
+    }
+
+    @Option(option = "fix", description = "Whether to apply the suggested fix to versions.props")
+    public final void setShouldFix(boolean shouldFix) {
+        this.shouldFix.set(shouldFix);
+    }
+
+    final void setShouldFix(Provider<Boolean> shouldFix) {
+        this.shouldFix.set(shouldFix);
+    }
+
+    @TaskAction
+    public final void checkNoUnusedPin() {
+        Set<String> artifacts = getClasspath().get();
+        VersionsProps versionsProps = VersionsProps.loadFromFile(getPropsFile().get().getAsFile().toPath());
+
+        Set<String> exactConstraints = versionsProps.getFuzzyResolver().exactMatches();
+        Stream<String> unusedExactConstraints = Sets.difference(exactConstraints, artifacts).stream();
+
+        Sets.SetView<String> unmatchedArtifacts = Sets.difference(artifacts, exactConstraints);
+        Stream<String> unusedGlobConstraints = versionsProps.getFuzzyResolver().globs().stream()
+                .filter(glob -> !unmatchedArtifacts.stream().anyMatch(glob::matches))
+                .map(FuzzyPatternResolver.Glob::getRawPattern);
+
+        ImmutableSet<String> unusedConstraints =
+                Stream.concat(unusedExactConstraints, unusedGlobConstraints).collect(ImmutableSet.toImmutableSet());
+
+        if (unusedConstraints.isEmpty()) {
+            return;
+        } else if (shouldFix.get()) {
+            getProject()
+                    .getLogger()
+                    .lifecycle("Removing unused pins from versions.props:\n"
+                            + unusedConstraints.stream()
+                                    .map(name -> String.format(" - '%s'", name))
+                                    .collect(Collectors.joining("\n")));
+            writeVersionsProps(getPropsFile().get().getAsFile(), unusedConstraints);
+            return;
+        }
+
+        throw new RuntimeException("There are unused pins in your versions.props: \n"
+                + unusedConstraints
+                + "\n\n"
+                + "Rerun with --fix to remove them.");
+    }
+
+    private static void writeVersionsProps(File propsFile, Set<String> unusedConstraints) {
+        List<String> lines = readVersionsPropsLines(propsFile);
+        try (BufferedWriter writer0 =
+                        Files.newBufferedWriter(propsFile.toPath(), StandardOpenOption.TRUNCATE_EXISTING);
+                PrintWriter writer = new PrintWriter(writer0)) {
+            for (String line : lines) {
+                if (unusedConstraints.stream().noneMatch(line::startsWith)) {
+                    writer.println(line);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static List<String> readVersionsPropsLines(File propsFile) {
+        try (Stream<String> lines = Files.lines(propsFile.toPath())) {
+            return lines.collect(ImmutableList.toImmutableList());
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading " + propsFile.toPath());
+        }
+    }
+
+    static Stream<String> getResolvedModuleIdentifiers(Project project, VersionRecommendationsExtension extension) {
+        return project.getConfigurations().stream()
+                .filter(Configuration::isCanBeResolved)
+                .filter(configuration -> !extension.shouldExcludeConfiguration(configuration.getName()))
+                .flatMap(configuration -> {
+                    try {
+                        ResolutionResult resolutionResult = configuration.getIncoming().getResolutionResult();
+                        return resolutionResult.getAllComponents().stream()
+                                .map(result -> result.getId())
+                                .filter(cid -> !cid.equals(resolutionResult.getRoot().getId())) // remove the project
+                                .filter(cid -> cid instanceof ModuleComponentIdentifier)
+                                .map(mcid -> ((ModuleComponentIdentifier) mcid).getModuleIdentifier())
+                                .map(mid -> mid.getGroup() + ":" + mid.getName());
+                    } catch (Exception e) {
+                        throw new RuntimeException(
+                                String.format(
+                                        "Error during resolution of the dependency graph of " + "configuration %s",
+                                        configuration),
+                                e);
+                    }
+                });
+    }
+}

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
@@ -26,7 +26,6 @@ import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/src/main/java/com/palantir/gradle/versions/FuzzyPatternResolver.java
+++ b/src/main/java/com/palantir/gradle/versions/FuzzyPatternResolver.java
@@ -21,9 +21,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
-import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 /** Adapted from {@code nebula.dependency-recommender}. */
@@ -53,20 +53,19 @@ public abstract class FuzzyPatternResolver {
         return cache;
     }
 
-    @Nullable
-    public final String patternFor(String key) {
+    public final Optional<String> patternFor(String key) {
         // Always prefer exact matches (which should be handled separately).
         if (exactMatches().contains(key)) {
-            return null;
+            return Optional.empty();
         }
 
         for (Glob glob : globs()) {
             if (glob.matches(key)) {
-                return glob.rawPattern;
+                return Optional.of(glob.rawPattern);
             }
         }
 
-        return null;
+        return Optional.empty();
     }
 
     public static class Builder extends ImmutableFuzzyPatternResolver.Builder {}
@@ -107,7 +106,11 @@ public abstract class FuzzyPatternResolver {
             return new Glob(pattern, glob, weight);
         }
 
-        private boolean matches(String key) {
+        String getRawPattern() {
+            return rawPattern;
+        }
+
+        boolean matches(String key) {
             return pattern.matcher(key).matches();
         }
 

--- a/src/main/java/com/palantir/gradle/versions/VersionsProps.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsProps.java
@@ -43,6 +43,10 @@ public final class VersionsProps {
                         .collect(Collectors.toMap(key -> key, this::constructPlatform));
     }
 
+    public FuzzyPatternResolver getFuzzyResolver() {
+        return fuzzyResolver;
+    }
+
     public static VersionsProps loadFromFile(Path path) {
         Properties recommendations = new Properties();
         try (BufferedReader reader = Files.newBufferedReader(path)) {
@@ -79,7 +83,7 @@ public final class VersionsProps {
      */
     public Optional<String> getStarVersion(ModuleIdentifier dependency) {
         String notation = dependency.getGroup() + ":" + dependency.getName();
-        return Optional.ofNullable(fuzzyResolver.patternFor(notation)).map(fuzzyResolver.versions()::get);
+        return fuzzyResolver.patternFor(notation).map(fuzzyResolver.versions()::get);
     }
 
     /**
@@ -91,7 +95,7 @@ public final class VersionsProps {
         if (fuzzyResolver.exactMatches().contains(notation)) {
             return Optional.empty();
         }
-        return Optional.ofNullable(fuzzyResolver.patternFor(notation)).map(patternToPlatform::get);
+        return fuzzyResolver.patternFor(notation).map(patternToPlatform::get);
     }
 
     private String constructPlatform(String glob) {

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -45,6 +45,7 @@ import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.VariantVersionMappingStrategy;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.util.GradleVersion;
 
 public class VersionsPropsPlugin implements Plugin<Project> {
@@ -99,6 +100,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
     }
 
     private static void applyToRootProject(Project project) {
+        project.getPluginManager().apply(LifecycleBasePlugin.class);
         project.getExtensions()
                 .create(VersionRecommendationsExtension.EXTENSION, VersionRecommendationsExtension.class, project);
         project.subprojects(subproject -> subproject.getPluginManager().apply(VersionsPropsPlugin.class));

--- a/src/test/groovy/com/palantir/gradle/versions/CheckUnusedConstraintIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/CheckUnusedConstraintIntegrationSpec.groovy
@@ -116,6 +116,25 @@ class CheckUnusedConstraintIntegrationSpec extends IntegrationSpec {
         file('versions.props').text.trim() == "org.slf4j:slf4j-api = 1.7.25"
     }
 
+    def 'Most specific glob should win'() {
+        when:
+        file('versions.props').text = """
+            org.slf4j:slf4j-* = 1.7.25
+            org.slf4j:* = 1.7.20
+        """.stripIndent()
+
+        buildFile << """
+        dependencies {
+            compile 'org.slf4j:slf4j-api'
+            compile 'org.slf4j:slf4j-jdk14'
+        }""".stripIndent()
+
+        then:
+        buildAndFailWith('There are unused pins in your versions.props: \n[org.slf4j:*]')
+        buildWithFixWorks()
+        file('versions.props').text.trim() == "org.slf4j:slf4j-* = 1.7.25"
+    }
+
     def 'Unused version should fail'() {
         when:
         file('versions.props').text = "notused:atall = 42.42"

--- a/src/test/groovy/com/palantir/gradle/versions/CheckUnusedConstraintIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/CheckUnusedConstraintIntegrationSpec.groovy
@@ -1,0 +1,158 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+
+class CheckUnusedConstraintIntegrationSpec extends IntegrationSpec {
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id 'java'
+                id 'com.palantir.versions-lock'
+                id 'com.palantir.versions-props'
+            }
+
+            repositories {
+                mavenCentral()
+                maven { url "${projectDir.toURI()}/maven" }
+            }
+        """.stripIndent()
+        file('gradle.properties').text = """
+        ignoreLockFile=true
+        """.stripIndent()
+        createFile('versions.props')
+    }
+
+    def buildSucceed() {
+        BuildResult result = runTasks( 'checkUnusedConstraints')
+        result.task(':checkUnusedConstraints').outcome == TaskOutcome.SUCCESS
+        result
+    }
+
+    void buildAndFailWith(String error) {
+        BuildResult result = runTasksAndFail('checkUnusedConstraints')
+        assert result.output.contains(error)
+    }
+
+    def buildWithFixWorks() {
+        def currentVersionsProps = file('versions.props').readLines()
+        // Check that running with --fix modifies the file
+        runTasks('checkUnusedConstraints', '--fix')
+        assert file('versions.props').readLines() != currentVersionsProps
+
+        // Check that the task now succeeds
+        runTasks('checkUnusedConstraints')
+    }
+
+    def 'checkVersionsProps does not resolve artifacts'() {
+        buildFile << """
+            dependencies {
+                compile 'com.palantir.product:foo:1.0.0'
+            }
+        """.stripIndent()
+        file("versions.props").text = ""
+
+        // We're not producing a jar for this dependency, so artifact resolution would fail
+        file('maven/com/palantir/product/foo/1.0.0/foo-1.0.0.pom') <<
+                pomWithJarPackaging("com.palantir.product", "foo", "1.0.0")
+
+        expect:
+        buildSucceed()
+    }
+
+    def 'Task should run as part of :check'() {
+        expect:
+        def result = runTasks('check', '-m')
+        result.output.contains(':checkUnusedConstraints')
+    }
+
+    def 'Version props conflict should succeed'() {
+        when:
+        file('versions.props').text = """
+            com.fasterxml.jackson.*:* = 2.9.3
+            com.fasterxml.jackson.core:jackson-annotations = 2.9.5
+        """.stripIndent()
+        buildFile << """
+        dependencies {
+            compile 'com.fasterxml.jackson.core:jackson-databind'
+        }""".stripIndent()
+
+        then:
+        buildSucceed()
+    }
+
+    def 'Most specific matching version should win'() {
+        when:
+        file('versions.props').text = """
+            org.slf4j:slf4j-api = 1.7.25
+            org.slf4j:* = 1.7.20
+        """.stripIndent()
+
+        buildFile << """
+        dependencies {
+            compile 'org.slf4j:slf4j-api'
+        }""".stripIndent()
+
+        then:
+        buildAndFailWith('There are unused pins in your versions.props: \n[org.slf4j:*]')
+        buildWithFixWorks()
+        file('versions.props').text.trim() == "org.slf4j:slf4j-api = 1.7.25"
+    }
+
+    def 'Unused version should fail'() {
+        when:
+        file('versions.props').text = "notused:atall = 42.42"
+
+        then:
+        buildAndFailWith("There are unused pins in your versions.props")
+        buildWithFixWorks()
+    }
+
+    def 'Unused check should use exact matching'() {
+        when:
+        file('versions.props').text = """
+            com.google.guava:guava-testlib = 23.0
+            com.google.guava:guava = 22.0
+        """.stripIndent()
+        buildFile << """
+        dependencies {
+            compile 'com.google.guava:guava'
+            compile 'com.google.guava:guava-testlib'
+        }""".stripIndent()
+
+        then:
+        buildSucceed()
+    }
+
+    static String pomWithJarPackaging(String group, String artifact, String version) {
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>$group</groupId>
+            <artifactId>$artifact</artifactId>
+            <packaging>jar</packaging>
+            <version>$version</version>
+            <description/>
+            <dependencies/>
+            </project>
+        """.stripIndent()
+    }
+}


### PR DESCRIPTION
## Before this PR
versions.props files would slowly accumulate unused constraints as dependencies were added and removed from a project

## After this PR
==COMMIT_MSG==
Add `checkUnusedConstraints` task which will ensure that the set of constraints in the versions.props file is minimal. Calling the task with `--fix` will automatically remove any unnecessary constraints.
==COMMIT_MSG==

## Possible downsides?
I tried this out on a few repos and it seemed to do the right thing, there may be cases where it does not and so it will prevent people from merging.

We'll probably also want to update the automation so that the "fix" is automatically applied as part of the upgrade

