### PR TITLE
Fix migration docs regarding baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ _You can also likely delete the 'conflict resolution' section of your versions.p
 
 
 ### How to make this work with Baseline
-Since baseline 3.0, GCV will just work out of the box with Baseline.
+GCV will just work out of the box with Baseline 3.0.0 and newer.
 
 _If still using Baseline 2.x, then you'll need to disable its own versions plugin which conflicts with GCV:_
 

--- a/README.md
+++ b/README.md
@@ -371,15 +371,16 @@ _You can also likely delete the 'conflict resolution' section of your versions.p
 
 
 ### How to make this work with Baseline
+Since baseline 3.0, GCV will just work out of the box with Baseline.
+
+_If still using Baseline 2.x, then you'll need to disable its own versions plugin which conflicts with GCV:_
+
 Add the following to your `gradle.properties` fully turn off nebula.dependency-recommender (only necessary if you use [`com.palantir.baseline`](https://github.com/palantir/gradle-baseline/#usage)):
 
 ```diff
  org.gradle.parallel=true
 +com.palantir.baseline-versions.disable=true
 ```
-
-_This should become unnecessary in a future version of Baseline._
-
 
 ### `dependencyRecommendations.getRecommendedVersion` -> `getVersion`
 If you rely on this Nebula function, then gradle-consistent-versions has a similar alternative:


### PR DESCRIPTION
## Before this PR

Instructions are only applicable to baseline 2.x, and will not be relevant anymore after https://github.com/palantir/gradle-baseline/pull/1169 lands.

## After this PR
==COMMIT_MSG==
Fix docs to be reflective of baseline 3.x.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

