### PR TITLE
Fail on duplicate constraints

### DIFF
--- a/changelog/@unreleased/pr-396.v2.yml
+++ b/changelog/@unreleased/pr-396.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Fail to parse a versions.props file if there are duplicate constraints
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/396

--- a/src/main/java/com/palantir/gradle/versions/VersionsProps.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsProps.java
@@ -68,7 +68,7 @@ public final class VersionsProps {
                             "Encountered duplicate constraint '" + key + "'. Please remove one of the entries");
                 }
                 versions.put(key, value);
-            } else if (!line.startsWith("#")) {
+            } else if (!line.trim().isEmpty() && !line.startsWith("#")) {
                 throw new IllegalArgumentException("Encountered invalid constraint " + line);
             }
         }

--- a/src/main/java/com/palantir/gradle/versions/VersionsProps.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsProps.java
@@ -68,6 +68,8 @@ public final class VersionsProps {
                             "Encountered duplicate constraint '" + key + "'. Please remove one of the entries");
                 }
                 versions.put(key, value);
+            } else if (!line.startsWith("#")) {
+                throw new IllegalArgumentException("Encountered invalid constraint " + line);
             }
         }
         builder.putAllVersions(versions);

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsTest.java
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsTest.java
@@ -45,7 +45,7 @@ public class VersionsPropsTest {
 
         assertThatThrownBy(() -> VersionsProps.loadFromFile(propsFile))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("invalid artifact");
+                .hasMessageContaining("invalid constraint");
     }
 
     @Test
@@ -55,6 +55,6 @@ public class VersionsPropsTest {
 
         assertThatThrownBy(() -> VersionsProps.loadFromFile(propsFile))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("missing version");
+                .hasMessageContaining("invalid constraint");
     }
 }


### PR DESCRIPTION
## Before this PR
We would silently ignore duplicate constraints preferring the last constraint encountered.

## After this PR
==COMMIT_MSG==
Fail to parse a versions.props file if there are duplicate constraints
==COMMIT_MSG==

## Possible downsides?
There might be some cases where users had duplicate constraints and so this will require manual action

