### PR TITLE
Run tests against 6.2-rc-1

### DIFF
--- a/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
+++ b/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
@@ -23,5 +23,5 @@ public final class GradleTestVersions {
     private GradleTestVersions() {}
 
     public static final List<String> GRADLE_VERSIONS =
-            ImmutableList.of(VersionsLockPlugin.MINIMUM_GRADLE_VERSION.getVersion(), "6.0.1");
+            ImmutableList.of(VersionsLockPlugin.MINIMUM_GRADLE_VERSION.getVersion(), "6.0.1", "6.2-rc-1");
 }


### PR DESCRIPTION
We're seeing some strange behaviour with `checkUnusedConstraints` on 6.2-rc-1 - just wanna make sure our tests still pass.