### PR TITLE
Improve errors for versions.props validation

### DIFF
--- a/changelog/@unreleased/pr-417.v2.yml
+++ b/changelog/@unreleased/pr-417.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: versions.props validation errors mention versions.props
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/417

--- a/src/main/java/com/palantir/gradle/versions/VersionsProps.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsProps.java
@@ -61,11 +61,17 @@ public final class VersionsProps {
                 String key = constraint.group(1);
                 String value = constraint.group(2);
                 Preconditions.checkArgument(
-                        CharMatcher.is(':').countIn(key) == 1, "Encountered invalid artifact name '%s'", key);
-                Preconditions.checkArgument(!value.isEmpty(), "Encountered missing version for artifact '%s'", value);
+                        CharMatcher.is(':').countIn(key) == 1,
+                        "Encountered invalid artifact name '%s' in versions.props",
+                        key);
+                Preconditions.checkArgument(
+                        !value.isEmpty(), "Encountered missing version for artifact '%s' in versions.props", value);
                 if (versions.containsKey(key)) {
-                    throw new RuntimeException(
-                            "Encountered duplicate constraint '" + key + "'. Please remove one of the entries");
+                    throw new RuntimeException("Encountered duplicate constraint for '"
+                            + key
+                            + "' in versions.props. Please remove one of the entries:\n"
+                            + String.format("    %s = %s\n", key, versions.get(key))
+                            + String.format("    %s = %s\n", key, value));
                 }
                 versions.put(key, value);
             } else if (!line.trim().isEmpty() && !line.startsWith("#")) {


### PR DESCRIPTION
## Before this PR

Slightly confusing errors in versions.props validation that don't mention `versions.props`.

## After this PR
==COMMIT_MSG==
versions.props validation errors mention versions.props
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

