### PR TITLE
Don't try to resolve legacy java configurations

### DIFF
--- a/changelog/@unreleased/pr-419.v2.yml
+++ b/changelog/@unreleased/pr-419.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix regression in 1.14.0 so that checkUnusedConstraints stops trying
+    to resolve legacy java configurations.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/419

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.file.RegularFile;
@@ -136,8 +135,7 @@ public class CheckUnusedConstraintsTask extends DefaultTask {
     }
 
     static Stream<String> getResolvedModuleIdentifiers(Project project, VersionRecommendationsExtension extension) {
-        return project.getConfigurations().stream()
-                .filter(Configuration::isCanBeResolved)
+        return GradleConfigurations.getResolvableConfigurations(project)
                 .filter(configuration -> !extension.shouldExcludeConfiguration(configuration.getName()))
                 .flatMap(configuration -> {
                     try {

--- a/src/main/java/com/palantir/gradle/versions/GradleConfigurations.java
+++ b/src/main/java/com/palantir/gradle/versions/GradleConfigurations.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.plugins.JavaPluginConvention;
+
+class GradleConfigurations {
+    /**
+     * Filters out both the unresolvable configurations but also the legacy java configurations that should not be
+     * resolved.
+     */
+    public static Stream<Configuration> getResolvableConfigurations(Project project) {
+        return project.getConfigurations().stream()
+                .filter(Configuration::isCanBeResolved)
+                .filter(conf -> !getLegacyJavaConfigurations(project).contains(conf.getName()));
+    }
+
+    /**
+     * Get the legacy java configurations that should not be resolved. If the project does not have the java plugin
+     * applied, this returns an empty set.
+     */
+    private static Set<String> getLegacyJavaConfigurations(Project project) {
+        JavaPluginConvention javaConvention = project.getConvention().findPlugin(JavaPluginConvention.class);
+        if (javaConvention == null) {
+            return ImmutableSet.of();
+        }
+        return javaConvention.getSourceSets().stream()
+                .flatMap(ss -> Stream.of(
+                        ss.getCompileConfigurationName(),
+                        ss.getRuntimeConfigurationName(),
+                        ss.getCompileOnlyConfigurationName()))
+                .collect(Collectors.toSet());
+    }
+
+    private GradleConfigurations() {}
+}

--- a/src/main/java/com/palantir/gradle/versions/GradleConfigurations.java
+++ b/src/main/java/com/palantir/gradle/versions/GradleConfigurations.java
@@ -24,7 +24,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.plugins.JavaPluginConvention;
 
-class GradleConfigurations {
+final class GradleConfigurations {
     /**
      * Filters out both the unresolvable configurations but also the legacy java configurations that should not be
      * resolved.


### PR DESCRIPTION
## Before this PR

`checkUnusedConfigurations` would sometimes trigger a gradle bug (https://github.com/gradle/gradle/issues/11844) on resolving certain java configurations (`compile`, `runtime`, `compileOnly`) that are only resolvable for backcompat reasons but for all intents and purposes should not be resolved.

## After this PR
==COMMIT_MSG==
Fix regression in 1.14.0 so that checkUnusedConstraints stops trying to resolve legacy java configurations.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

