### PR TITLE
Fail fast if outgoing configurations are realized early

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -227,6 +227,21 @@ public class VersionsLockPlugin implements Plugin<Project> {
         // (but that's internal)
         project.getPluginManager().apply("java-base");
 
+        // This is helpful to short-circuit bad interactions with other plugins and pinpoint which code path caused
+        // the error. The goal is to hook up guard rails against the same configurations that are lazily configured by
+        // configurePublishConstraints (which usually happens too late to produce a good stack-trace: in the root
+        // project's afterEvaluate).
+        // Ideally, this code would go happen together with that function, and be wired up to compute the locked
+        // configurations lazily, rather than eagerly but inside rootProject.afterEvaluate which happens very late.
+        project.allprojects(subproject -> {
+            subproject.getPluginManager().withPlugin("java", plugin -> {
+                guardConfigurationFromEarlyResolution(
+                        project, subproject.getConfigurations().named(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME));
+                guardConfigurationFromEarlyResolution(
+                        project, subproject.getConfigurations().named(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME));
+            });
+        });
+
         // afterEvaluate is necessary to ensure all projects' dependencies have been configured, because we
         // need to copy them eagerly before we add the constraints from the lock file.
         //
@@ -237,16 +252,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
         // configurations before we get a change to add constraints to them.
         //
         // [1]:https://github.com/JetBrains/intellij-community/commit/f394c51cff59c69bbaf63a8bf67cefbad9e357aa#diff-04b9936e4249a0f5727414555b76c4b9R123
-
-        project.allprojects(subproject -> {
-            subproject.getPluginManager().withPlugin("java", plugin -> {
-                guardConfigurationFromEarlyResolution(
-                        project, subproject.getConfigurations().named(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME));
-                guardConfigurationFromEarlyResolution(
-                        project, subproject.getConfigurations().named(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME));
-            });
-        });
-
         project.afterEvaluate(p -> {
             p.getSubprojects().forEach(subproject -> p.evaluationDependsOn(subproject.getPath()));
 


### PR DESCRIPTION
## Before this PR

Hard to debug bad interactions with other plugins.
For instance, the kotlin plugin realizes the dependencies of a bunch of java configurations early (at configuration time), and GCV doesn't allow that (see https://github.com/palantir/gradle-consistent-versions/issues/423#issuecomment-586383644).

However, by the time GCV fails, it will fail like so, and the stack trace won't point to who "included this configuration in dependency resolution" in the first place.

```
org.gradle.api.InvalidUserDataException: Cannot change dependencies of dependency configuration ':<redacted>:apiElements' after it has been included in dependency resolution.
```

## After this PR
==COMMIT_MSG==
Immediately throw an error capturing the stacktrace when other plugins / gradle code are attempting to realize configuration dependencies/constraints early (at configuration-time) and throw an error.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

