### PR TITLE
Remove nebula dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ sourceCompatibility = 1.8
 
 dependencies {
     implementation 'com.google.guava:guava'
-    implementation 'com.netflix.nebula:nebula-dependency-recommender'
+    compileOnly 'com.netflix.nebula:nebula-dependency-recommender'
 
     testCompile platform('org.junit:junit-bom')
     testImplementation 'com.netflix.nebula:nebula-test'

--- a/src/main/java/com/palantir/gradle/versions/NebulaUtils.java
+++ b/src/main/java/com/palantir/gradle/versions/NebulaUtils.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.gradle.versions;
+
+import netflix.nebula.dependency.recommender.RecommendationStrategies;
+import netflix.nebula.dependency.recommender.provider.RecommendationProviderContainer;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+
+public final class NebulaUtils {
+
+    static void verifyRecommendationStrategy(Project project) {
+        RecommendationProviderContainer container =
+                project.getExtensions().findByType(RecommendationProviderContainer.class);
+        if (container.getStrategy() == RecommendationStrategies.OverrideTransitives) {
+            throw new GradleException("Must not use strategy OverrideTransitives for "
+                    + project
+                    + ". Use this instead: dependencyRecommendations { strategy ConflictResolved }");
+        }
+    }
+
+    private NebulaUtils() {}
+}

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -56,8 +56,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
-import netflix.nebula.dependency.recommender.RecommendationStrategies;
-import netflix.nebula.dependency.recommender.provider.RecommendationProviderContainer;
 import org.gradle.api.GradleException;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectProvider;
@@ -432,14 +430,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
         project.subprojects(subproject -> {
             subproject.afterEvaluate(sub -> {
                 sub.getPluginManager().withPlugin("nebula.dependency-recommender", plugin -> {
-                    RecommendationProviderContainer container =
-                            sub.getExtensions().findByType(RecommendationProviderContainer.class);
-                    if (container.getStrategy() == RecommendationStrategies.OverrideTransitives) {
-                        throw new GradleException("Must not use strategy OverrideTransitives for "
-                                + sub
-                                + ". "
-                                + "Use this instead: dependencyRecommendations { strategy ConflictResolved }");
-                    }
+                    NebulaUtils.verifyRecommendationStrategy(sub);
                 });
             });
         });


### PR DESCRIPTION
## Before this PR
We pulled in nebula (and transitively the kotlin runtime) just so we could verify the recommendation strategy

## After this PR
Change the dependency to be compileOnly and guard the access so that we're guaranteed to have the classes on the classpath if we execute the code.

## Possible downsides?
N/A

