### PR TITLE
relax constraint for configure-on-demand

### DIFF
--- a/changelog/@unreleased/pr-489.v2.yml
+++ b/changelog/@unreleased/pr-489.v2.yml
@@ -1,0 +1,11 @@
+type: improvement
+improvement:
+  description: This change relaxes the precondition constraint that checks that
+    configure-on-demand is disabled. We now only require it to be disabled
+    when running the "verifyLocks" task, or when invoked with
+    "--write-locks".
+
+    This gives projects more flexibility to flag on configure-on-demand in certain 
+    scenarios where it might make sense.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/489

--- a/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
+++ b/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.versions;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.MapDifference.ValueDifference;
 import com.google.common.collect.Maps;
@@ -69,6 +70,11 @@ public class VerifyLocksTask extends DefaultTask {
 
     @TaskAction
     public final void taskAction() throws IOException {
+        Preconditions.checkState(
+                !getProject().getGradle().getStartParameter().isConfigureOnDemand(),
+                "configure-on-demand cannot be enabled when running the 'verifyLocks' task;"
+                        + " please remove 'org.gradle.configureondemand' from your gradle.properties");
+
         verifyLocksForScope(LockState::productionLinesByModuleIdentifier);
         verifyLocksForScope(LockState::testLinesByModuleIdentifier);
         Files.touch(outputFile);

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -434,10 +434,13 @@ public class VersionsLockPlugin implements Plugin<Project> {
             throw new GradleException("Must be applied only to root project");
         }
 
-        Preconditions.checkState(
-                !project.getGradle().getStartParameter().isConfigureOnDemand(),
-                "Gradle Consistent Versions doesn't currently work with configure-on-demand, please remove"
-                        + " 'org.gradle.configureondemand' from your gradle.properties");
+        // check that configure-on-demand is false when running with --write-locks
+        if (project.getGradle().getStartParameter().isWriteDependencyLocks()) {
+            Preconditions.checkState(
+                    !project.getGradle().getStartParameter().isConfigureOnDemand(),
+                    "configure-on-demand cannot be enabled when gradle is invoked with --write-locks;"
+                            + " please remove 'org.gradle.configureondemand' from your gradle.properties");
+        }
 
         Multimap<String, Project> coordinateDuplicates = LinkedHashMultimap.create();
         Set<Project> subprojectsLeft = new HashSet<>(project.getSubprojects());


### PR DESCRIPTION
This change relaxes the precondition constraint that checks that
configure-on-demand is disabled. We now only require it to be disabled
when running the "verifyLocks" task, or when invoked with
"--write-locks".

## Before this PR
Previously GCV would throw when the plugin was applied to any project that had set `org.gradle.configureondemand=true`, but this seems overly restrictive. The constraint should be necessary only when verifying or updating the lockfile, which requires configuring all projects.

## After this PR
==COMMIT_MSG==
This change relaxes the precondition constraint that checks that
configure-on-demand is disabled. We now only require it to be disabled
when running the "verifyLocks" task, or when invoked with
"--write-locks".

This gives projects more flexibility to flag on configure-on-demand in certain scenarios where it might make sense.
==COMMIT_MSG==

## Possible downsides?
Enabling "dual-mode" configure-on-demand (e.g. disabled when writing/verifying locks, and enabled otherwise) could be tricky, since it can only be enabled/disabled via the gradle property or command line switch. That means in order for users to get the best of both worlds that this change tries to address, they'll likely have to do some tricks with the gradle wrapper script.
