### PR TITLE
Always add all constraints from the lock file to publications

### DIFF
--- a/changelog/@unreleased/pr-504.v2.yml
+++ b/changelog/@unreleased/pr-504.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: Expose all lock file constraints as derived from `versions.lock` in
+    all publications derived from `components.java`. This will most likely produce
+    surprising behaviour when publishing module metadata! However, we are not using
+    it internally for now, and we are planning a better solution that addresses the
+    problems with the current implementation.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/504

--- a/src/test/groovy/com/palantir/gradle/versions/SlsPackagingCompatibilityIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/SlsPackagingCompatibilityIntegrationSpec.groovy
@@ -78,13 +78,6 @@ class SlsPackagingCompatibilityIntegrationSpec extends IntegrationSpec {
                     maximumVersion = '1.x.x'
                 }
             }
-            
-            configurations.runtimeClasspath.incoming.beforeResolve {
-                // Signal that this configuration was resolved, which we expect, because this project is expected to be
-                // consumed as part of createManifest, and `runtimeElements` triggers resolution of `runtimeClasspath`
-                buildDir.mkdirs()
-                file("\$buildDir/resolved-runtime").text = 'done'
-            }
         """.stripIndent())
 
         addSubproject('service', """
@@ -106,7 +99,6 @@ class SlsPackagingCompatibilityIntegrationSpec extends IntegrationSpec {
         ] as Set
         // Ensure that 'jar' was not run on the API project
         wroteLocks.task(':api:jar') == null
-        new File(projectDir, 'api/build/resolved-runtime').exists()
 
         runTasks('createManifest', 'verifyLocks')
     }

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -855,7 +855,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def "#gradleVersionNumber: published constraints are derived from filtered lock file"() {
+    def "#gradleVersionNumber: published constraints are derived from lock file"() {
         setup:
         gradleVersion = gradleVersionNumber
 
@@ -916,11 +916,11 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
                 new MetadataFile.Variant(
                         name: 'apiElements',
                         dependencies: [logbackDep],
-                        dependencyConstraints: [logbackDep, slf4jDep]),
+                        dependencyConstraints: [junitDep, logbackDep, slf4jDep]),
                 new MetadataFile.Variant(
                         name: 'runtimeElements',
                         dependencies: [logbackDep],
-                        dependencyConstraints: [logbackDep, slf4jDep]),
+                        dependencyConstraints: [junitDep, logbackDep, slf4jDep]),
         ] as Set
 
         and: "bar's metadata file has the right dependency constraints"
@@ -931,11 +931,11 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
                 new MetadataFile.Variant(
                         name: 'apiElements',
                         dependencies: [junitDep],
-                        dependencyConstraints: [junitDep]),
+                        dependencyConstraints: [junitDep, logbackDep, slf4jDep]),
                 new MetadataFile.Variant(
                         name: 'runtimeElements',
                         dependencies: [junitDep],
-                        dependencyConstraints: [junitDep]),
+                        dependencyConstraints: [junitDep, logbackDep, slf4jDep]),
         ] as Set
 
         where:


### PR DESCRIPTION
## Before this PR

Involving any java gradle project in resolution by depending on it triggered the resolution of its `compileClasspath` or `runtimeClasspath` configurations, which can be very costly and unnecessary.

This behaviour was introduced in #191, in order to filter to only the dependencies used by a particular project when deciding what constraints from `versions.lock` to include in a publication.

When publishing maven POM files though, this filtering doesn't make a difference, because constraints in `<dependencyManagement>` that don't correspond to a real dependency in that component's downstream subtree will be ignored anyway (couldn't find a link but this is my observed behaviour of maven resolution, and specifically gradle's implementation of it).

For publishing maven metadata files, where transitive constraints get imported as if having been declared by the consumer gradle project (and hence have the ability to bump up dependencies from _unrelated_ parts of your dependency tree) it could still be desirable to only publish constraints for the dependencies being used.
This is in order to avoid the situation where a conjure API that's part of a service would publish constraints on service libraries like witchcraft, just because it's in `versions.lock`, thus bumping the witchcraft of all consumers of that API.

We're not currently using module metadata internally though, so this issue can be dealt with at a later point in a separate PR.

## After this PR
==COMMIT_MSG==
Expose all lock file constraints as derived from `versions.lock` in all publications derived from `components.java`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

