### PR TITLE
Revert "Excavator: Render CircleCI file using template specified in .circleci/template.sh"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,36 +118,6 @@ jobs:
       - store_test_results: { path: ~/junit }
       - store_artifacts: { path: ~/artifacts }
 
-
-  unit-test-14:
-    docker: [{ image: 'circleci/openjdk:11-node' }]
-    resource_class: large
-    environment:
-      CIRCLE_TEST_REPORTS: /home/circleci/junit
-      CIRCLE_ARTIFACTS: /home/circleci/artifacts
-      GRADLE_OPTS: -Dorg.gradle.jvmargs='-XX:MaxMetaspaceSize=256m' -Dorg.gradle.workers.max=4
-      _JAVA_OPTIONS: -XX:ActiveProcessorCount=4 -Xmx1177m -XX:MaxMetaspaceSize=512m  -XX:ErrorFile=/home/circleci/artifacts/hs_err_pid%p.log -XX:HeapDumpPath=/home/circleci/artifacts
-      JAVA_HOME: /opt/java14
-    steps:
-      - checkout
-      - run:
-          name: Install Java
-          command: |
-            sudo mkdir -p /opt/java && cd /opt/java && sudo chown -R circleci:circleci .
-            curl https://cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-linux_x64.tar.gz | tar -xzf - -C /opt/java
-            sudo ln -s /opt/java/zulu*/ /opt/java14
-      - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
-      - restore_cache: { key: 'unit-test-14-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
-      - run: ./gradlew --parallel --stacktrace --continue test -Pcom.palantir.baseline-error-prone.disable
-      - save_cache:
-          key: 'unit-test-14-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
-          paths: [ ~/.gradle/caches ]
-      - run:
-          command: mkdir -p ~/junit && find . -type f -regex ".*/build/.*TEST.*xml" -exec cp --parents {} ~/junit/ \;
-          when: always
-      - store_test_results: { path: ~/junit }
-      - store_artifacts: { path: ~/artifacts }
-
   trial-publish:
     docker: [{ image: 'circleci/openjdk:8u222-stretch-node' }]
     environment:
@@ -206,9 +176,6 @@ workflows:
       - unit-test-11:
           filters: { tags: { only: /.*/ } }
 
-      - unit-test-14:
-          filters: { tags: { only: /.*/ } }
-
       - check:
           requires: [ compile ]
           filters: { tags: { only: /.*/ } }
@@ -221,5 +188,5 @@ workflows:
           filters: { branches: { ignore: develop } }
 
       - publish:
-          requires: [ unit-test, unit-test-11, unit-test-14, check, trial-publish ]
+          requires: [ unit-test, unit-test-11, check, trial-publish ]
           filters: { tags: { only: /.*/ }, branches: { only: develop } }


### PR DESCRIPTION
Reverts palantir/gradle-consistent-versions#502

unit-test-14 cannot succed using old gradle 5.3 that we still test against, and prevents us from publishing