### PR TITLE
Check unused constraints can be up-to-date

### DIFF
--- a/changelog/@unreleased/pr-522.v2.yml
+++ b/changelog/@unreleased/pr-522.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Check unused constraints can be up-to-date.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/522

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
@@ -55,6 +55,7 @@ public class CheckUnusedConstraintsTask extends DefaultTask {
         shouldFix.set(false);
         setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
         setDescription("Ensures all versions in your versions.props correspond to an actual gradle dependency");
+        getOutputs().upToDateWhen(_task -> true); // task has no outputs, this is need for it to be up to date
     }
 
     final void setPropsFile(File propsFile) {
@@ -69,6 +70,11 @@ public class CheckUnusedConstraintsTask extends DefaultTask {
     @InputFile
     public final Property<RegularFile> getPropsFile() {
         return propsFileProperty;
+    }
+
+    @Input
+    public final Property<Boolean> getShouldFix() {
+        return shouldFix;
     }
 
     @Option(option = "fix", description = "Whether to apply the suggested fix to versions.props")


### PR DESCRIPTION
This task takes 1.8 seconds for me, and only is relevant in a few cases (when I
change my props file, when I change my classpath). Here, we enable the
task to be up-to-date more frequently.