### PR TITLE
Enforce lock constraints using shared platform

### DIFF
--- a/changelog/@unreleased/pr-557.v2.yml
+++ b/changelog/@unreleased/pr-557.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Manage lock file constraints using a single gradle "platform", reducing
+    the number of constraints that have to be created.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/557

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -21,6 +21,8 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 public class ConsistentVersionsPlugin implements Plugin<Project> {
+    static final String CONSISTENT_VERSIONS_USAGE = "consistent-versions-usage";
+
     @Override
     public final void apply(Project project) {
         if (!project.getRootProject().equals(project)) {

--- a/src/main/java/com/palantir/gradle/versions/DependencyConstraintCreator.java
+++ b/src/main/java/com/palantir/gradle/versions/DependencyConstraintCreator.java
@@ -1,0 +1,24 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions;
+
+import org.gradle.api.artifacts.DependencyConstraint;
+
+@FunctionalInterface
+public interface DependencyConstraintCreator {
+    DependencyConstraint create(Object var1);
+}

--- a/src/main/java/com/palantir/gradle/versions/DependencyConstraintCreator.java
+++ b/src/main/java/com/palantir/gradle/versions/DependencyConstraintCreator.java
@@ -16,9 +16,14 @@
 
 package com.palantir.gradle.versions;
 
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyConstraint;
 
 @FunctionalInterface
 public interface DependencyConstraintCreator {
-    DependencyConstraint create(Object var1);
+    default DependencyConstraint create(Object notation) {
+        return create(notation, _constraint -> {});
+    }
+
+    DependencyConstraint create(Object notation, Action<? super DependencyConstraint> action);
 }

--- a/src/main/java/com/palantir/gradle/versions/DependencyConstraintCreator.java
+++ b/src/main/java/com/palantir/gradle/versions/DependencyConstraintCreator.java
@@ -20,7 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyConstraint;
 
 @FunctionalInterface
-public interface DependencyConstraintCreator {
+interface DependencyConstraintCreator {
     default DependencyConstraint create(Object notation) {
         return create(notation, _constraint -> {});
     }

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -839,22 +839,16 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
     private static void configureAllProjectsUsingConstraints(
             Project rootProject,
-            Path gradleLockfile,
+            Path _gradleLockfile,
             Map<Project, LockedConfigurations> lockedConfigurations,
             ProjectDependency locksDependency) {
 
-        List<DependencyConstraint> publishableConstraints = constructPublishableConstraintsFromLockFile(
-                gradleLockfile, rootProject.getDependencies().getConstraints());
-
-        rootProject.allprojects(subproject -> configureUsingConstraints(
-                subproject, locksDependency, publishableConstraints, lockedConfigurations.get(subproject)));
+        rootProject.allprojects(subproject ->
+                configureUsingConstraints(subproject, locksDependency, lockedConfigurations.get(subproject)));
     }
 
     private static void configureUsingConstraints(
-            Project subproject,
-            ProjectDependency locksDependency,
-            List<DependencyConstraint> publishableConstraints,
-            LockedConfigurations lockedConfigurations) {
+            Project subproject, ProjectDependency locksDependency, LockedConfigurations lockedConfigurations) {
         Configuration locksConfiguration = subproject
                 .getConfigurations()
                 .create(LOCK_CONSTRAINTS_CONFIGURATION_NAME, locksConf -> {
@@ -949,22 +943,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
                         v.strictly(version);
                     });
                     constraint.because("Locked by versions.lock");
-                }))
-                .collect(Collectors.toList());
-    }
-
-    private static List<DependencyConstraint> constructPublishableConstraintsFromLockFile(
-            Path gradleLockfile, DependencyConstraintHandler constraintHandler) {
-        LockState lockState = new ConflictSafeLockFile(gradleLockfile).readLocks();
-        // We only publish the production locks.
-        return lockState.productionLinesByModuleIdentifier().entrySet().stream()
-                .map(e -> e.getKey() + ":" + e.getValue().version())
-                .map(notation -> constraintHandler.create(notation, constraint -> {
-                    constraint.version(v -> {
-                        String version = Objects.requireNonNull(constraint.getVersion());
-                        v.require(version);
-                    });
-                    constraint.because("Computed from com.palantir.consistent-versions' versions.lock");
                 }))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -88,7 +88,6 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
@@ -870,28 +869,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
         configurationsToLock.forEach(conf -> {
             conf.extendsFrom(locksConfiguration);
             VersionsLockPlugin.ensureNoFailOnVersionConflict(conf);
-        });
-
-        NamedDomainObjectProvider<Configuration> publishConstraints = subproject
-                .getConfigurations()
-                .register("gcvPublishConstraints", conf -> {
-                    conf.setDescription("Publishable constraints from the GCV versions.lock file");
-                    conf.setCanBeResolved(false);
-                    conf.setCanBeConsumed(false);
-                    conf.getDependencyConstraints().addAll(publishableConstraints);
-                });
-
-        // Enrich the configurations being published as part of the java component (components.java)
-        // with constraints generated from the lock file.
-        subproject.getPluginManager().withPlugin("java", _plugin -> {
-            subproject
-                    .getConfigurations()
-                    .named(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME)
-                    .configure(conf -> conf.extendsFrom(publishConstraints.get()));
-            subproject
-                    .getConfigurations()
-                    .named(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
-                    .configure(conf -> conf.extendsFrom(publishConstraints.get()));
         });
     }
 

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -88,6 +88,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
@@ -869,6 +870,28 @@ public class VersionsLockPlugin implements Plugin<Project> {
         configurationsToLock.forEach(conf -> {
             conf.extendsFrom(locksConfiguration);
             VersionsLockPlugin.ensureNoFailOnVersionConflict(conf);
+        });
+
+        NamedDomainObjectProvider<Configuration> publishConstraints = subproject
+                .getConfigurations()
+                .register("gcvPublishConstraints", conf -> {
+                    conf.setDescription("Publishable constraints from the GCV versions.lock file");
+                    conf.setCanBeResolved(false);
+                    conf.setCanBeConsumed(false);
+                    conf.getDependencyConstraints().addAll(publishableConstraints);
+                });
+
+        // Enrich the configurations being published as part of the java component (components.java)
+        // with constraints generated from the lock file.
+        subproject.getPluginManager().withPlugin("java", _plugin -> {
+            subproject
+                    .getConfigurations()
+                    .named(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME)
+                    .configure(conf -> conf.extendsFrom(publishConstraints.get()));
+            subproject
+                    .getConfigurations()
+                    .named(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
+                    .configure(conf -> conf.extendsFrom(publishConstraints.get()));
         });
     }
 

--- a/src/main/java/com/palantir/gradle/versions/VersionsProps.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsProps.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 
 /** A {@code versions.props} file. */
 public final class VersionsProps {
@@ -95,15 +94,15 @@ public final class VersionsProps {
         return new VersionsProps(FuzzyPatternResolver.builder().build());
     }
 
-    public Stream<DependencyConstraint> constructConstraints(DependencyConstraintHandler handler) {
+    public Stream<DependencyConstraint> constructConstraints(DependencyConstraintCreator constraintCreator) {
         Map<String, String> versions = fuzzyResolver.versions();
         return Stream.concat(
                 fuzzyResolver.exactMatches().stream()
                         .map(key -> key + ":" + versions.get(key))
-                        .map(handler::create),
+                        .map(constraintCreator::create),
                 patternToPlatform.entrySet().stream()
                         .map(entry -> entry.getValue() + ":" + versions.get(entry.getKey()))
-                        .map(handler::create));
+                        .map(constraintCreator::create));
     }
 
     /**

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -35,9 +35,12 @@ import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ExternalDependency;
 import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
@@ -58,6 +61,15 @@ public class VersionsPropsPlugin implements Plugin<Project> {
     @Override
     public final void apply(Project project) {
         checkPreconditions();
+
+        // Shared across root project / other project
+        ObjectFactory objectFactory = project.getObjects();
+        Usage gcvVersionsPropsUsage = objectFactory.named(Usage.class, "gcv-versions-props");
+        String gcvVersionsPropsCapability = "gcv:versions-props:0";
+
+        VersionsProps versionsProps = loadVersionsProps(
+                project.getRootProject().file("versions.props").toPath());
+
         if (project.getRootProject().equals(project)) {
             applyToRootProject(project);
 
@@ -71,28 +83,38 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                                 .set(project.getLayout().getProjectDirectory().file("versions.props"));
                     });
             project.getTasks().named("check").configure(task -> task.dependsOn(checkNoUnusedConstraints));
+
+            // Create "platform" configuration in root project, which will hold the versions props constraints
+            project.getConfigurations().register("gcvVersionsPropsConstraints", conf -> {
+                conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, gcvVersionsPropsUsage);
+                conf.getOutgoing().capability(gcvVersionsPropsCapability);
+                conf.setCanBeResolved(false);
+                conf.setCanBeConsumed(true);
+                conf.setVisible(false);
+
+                // Note: don't add constraints to the ConstraintHandler, only call `create` / `platform` on it.
+                addVersionsPropsConstraints(project.getDependencies().getConstraints(), conf, versionsProps);
+            });
         }
 
         VersionRecommendationsExtension extension =
                 project.getRootProject().getExtensions().getByType(VersionRecommendationsExtension.class);
 
-        VersionsProps versionsProps = loadVersionsProps(
-                project.getRootProject().file("versions.props").toPath());
-
         NamedDomainObjectProvider<Configuration> rootConfiguration = project.getConfigurations()
                 .register(ROOT_CONFIGURATION_NAME, conf -> {
                     conf.setCanBeResolved(false);
+                    conf.setCanBeConsumed(false);
                     conf.setVisible(false);
+
+                    // Wire in the constraints from the main configuration.
+                    conf.getDependencies()
+                            .add(createDepOnRootConstraintsConfiguration(
+                                    project, gcvVersionsPropsUsage, gcvVersionsPropsCapability));
                 });
 
         project.getConfigurations().configureEach(conf -> {
             setupConfiguration(project, extension, rootConfiguration.get(), versionsProps, conf);
         });
-
-        // Note: don't add constraints to this, only call `create` / `platform` on it.
-        DependencyConstraintHandler constraintHandler =
-                project.getDependencies().getConstraints();
-        rootConfiguration.configure(conf -> addVersionsPropsConstraints(constraintHandler, conf, versionsProps));
 
         log.info("Configuring rules to assign *-constraints to platforms in {}", project);
         project.getDependencies()
@@ -103,10 +125,20 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         configureResolvedVersionsWithVersionMapping(project);
     }
 
+    private static ProjectDependency createDepOnRootConstraintsConfiguration(
+            Project project, Usage usage, String capability) {
+        ProjectDependency projectDep =
+                ((ProjectDependency) project.getDependencies().create(project.getRootProject()));
+        projectDep.capabilities(capabilities -> capabilities.requireCapability(capability));
+        projectDep.attributes(attrs -> attrs.attribute(Usage.USAGE_ATTRIBUTE, usage));
+        return projectDep;
+    }
+
     private static void applyToRootProject(Project project) {
         project.getPluginManager().apply(LifecycleBasePlugin.class);
         project.getExtensions()
                 .create(VersionRecommendationsExtension.EXTENSION, VersionRecommendationsExtension.class, project);
+
         project.subprojects(subproject -> subproject.getPluginManager().apply(VersionsPropsPlugin.class));
     }
 

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -40,7 +40,6 @@ import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Provider;
@@ -63,8 +62,10 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         checkPreconditions();
 
         // Shared across root project / other project
-        ObjectFactory objectFactory = project.getObjects();
-        Usage gcvVersionsPropsUsage = objectFactory.named(Usage.class, "gcv-versions-props");
+        // This must be usable during VersionsLockPlugin's resolution of unifiedClasspath, so the usage
+        // must be 'compatible with' (or the same as) the one for the VersionsLockPlugin's own configurations.
+        Usage gcvVersionsPropsUsage =
+                project.getObjects().named(Usage.class, ConsistentVersionsPlugin.CONSISTENT_VERSIONS_USAGE);
         String gcvVersionsPropsCapability = "gcv:versions-props:0";
 
         VersionsProps versionsProps = loadVersionsProps(

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -36,7 +36,6 @@ import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ExternalDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -93,8 +92,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                 conf.setCanBeConsumed(true);
                 conf.setVisible(false);
 
-                // Note: don't add constraints to the ConstraintHandler, only call `create` / `platform` on it.
-                addVersionsPropsConstraints(project.getDependencies().getConstraints(), conf, versionsProps);
+                addVersionsPropsConstraints(project.getDependencies().getConstraints()::create, conf, versionsProps);
             });
         }
 
@@ -286,9 +284,9 @@ public class VersionsPropsPlugin implements Plugin<Project> {
     }
 
     private static void addVersionsPropsConstraints(
-            DependencyConstraintHandler constraintHandler, Configuration conf, VersionsProps versionsProps) {
+            DependencyConstraintCreator constraintCreator, Configuration conf, VersionsProps versionsProps) {
         ImmutableList<DependencyConstraint> constraints =
-                versionsProps.constructConstraints(constraintHandler).collect(ImmutableList.toImmutableList());
+                versionsProps.constructConstraints(constraintCreator).collect(ImmutableList.toImmutableList());
         log.info("Adding constraints to {}: {}", conf, constraints);
         constraints.forEach(conf.getDependencyConstraints()::add);
     }


### PR DESCRIPTION
## Before this PR

Creating lots of constraints into every single configuration being resolved (even though technically only once per project, after which they get inherited by all configurations).

This can lead to super large build scans (300MB for a large internal monorepo) where constraints are needlessly duplicated.

## After this PR
==COMMIT_MSG==
Manage lock file constraints using a single platform, reducing the number of constraints that have to be created.

This works in a similar way to [Java Platform Plugin](https://docs.gradle.org/current/userguide/java_platform_plugin.html). We can't just use that plugin directly, as it makes too many assumptions about the structure of the build where it's applied (e.g. needs its own project that isn't otherwise a java project, to hold the platform) that we can't make in GCV.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

