### PR TITLE
fix com.palantir.versions-props break

### DIFF
--- a/changelog/@unreleased/pr-576.v2.yml
+++ b/changelog/@unreleased/pr-576.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'Fix versions-props plugin regression from #557 (1.26.0) in some circumstances'
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/576

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -55,6 +55,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
     private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("5.2");
     private static final ImmutableSet<String> JAVA_PUBLISHED_CONFIGURATION_NAMES =
             ImmutableSet.of(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME, JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME);
+    private static final String GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME = "gcvVersionsPropsConstraints";
 
     @Override
     public final void apply(Project project) {
@@ -85,7 +86,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             project.getTasks().named("check").configure(task -> task.dependsOn(checkNoUnusedConstraints));
 
             // Create "platform" configuration in root project, which will hold the versions props constraints
-            project.getConfigurations().register("gcvVersionsPropsConstraints", conf -> {
+            project.getConfigurations().register(GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME, conf -> {
                 conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, gcvVersionsPropsUsage);
                 conf.getOutgoing().capability(gcvVersionsPropsCapability);
                 conf.setCanBeResolved(false);
@@ -152,6 +153,10 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         // For rootConfiguration, unlike other configurations, this is the only customization necessary.
         if (conf.getName().equals(ROOT_CONFIGURATION_NAME)) {
             conf.withDependencies(deps -> provideVersionsFromStarDependencies(versionsProps, deps));
+            return;
+        }
+
+        if (conf.getName().equals(GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME)) {
             return;
         }
 


### PR DESCRIPTION
## Before this PR

Get breaks if certain configurations are resolved/touched during the configuration stage.
This is because in #557, we incorrectly further configure the internal configuration used to hold versions.props constraints, which sometimes breaks like this: https://github.com/palantir/gradle-revapi/pull/307

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix versions-props plugin regression from #557 (1.26.0) in some circumstances 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

