### PR TITLE
Update version alignment link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Note that this does not force okhttp to exactly 3.12.0, it just declares that yo
 <a name="rule-specificity">[1]</a>: If multiple lines from `versions.props` match a particular jar, **the most specific one** will be chosen (the one with the most characters being different from `*`).
 This has the side effect that a line referring specifically to a jar is independent, and that jar's version never gets aligned to the versions of other jars, even if there are other lines containing `*` which would otherwise match that jar. 
 
-[virtual platform]: https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:version_alignment
+[virtual platform]: https://docs.gradle.org/current/userguide/dependency_version_alignment.html
 
 
 ### versions.lock: compact representation of your prod classpath


### PR DESCRIPTION
## Before this PR

https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:version_alignment is no longer accessible. The static link to the 5.0 version still works (https://docs.gradle.org/current/userguide/managing_transitive_dependencies.html#sec:version_alignment) but the docs for 6.x are more elaborate.

## After this PR
==COMMIT_MSG==
Update version alignment link in readme
==COMMIT_MSG==