### PR TITLE
Add property to skip writing lock file

### DIFF
--- a/changelog/@unreleased/pr-613.v2.yml
+++ b/changelog/@unreleased/pr-613.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add property to skip writing lock file
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/613

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -983,4 +983,31 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         where:
         gradleVersionNumber << GRADLE_VERSIONS
     }
+
+    def "#gradleVersionNumber: does not write lock file when property 'gcvSkipWriteLocks' is set"() {
+        gradleVersion = gradleVersionNumber
+
+        buildFile << """
+            apply plugin: 'java'
+            dependencies {
+                testImplementation 'org.slf4j:slf4j-api:1.7.25'
+            }
+        """.stripIndent()
+
+        def lockFileContent = """\
+            # Run ./gradlew --write-locks to regenerate this file
+        """.stripIndent()
+
+        file('versions.lock').text = lockFileContent
+
+        expect:
+        def result = runTasks("--write-locks", "-PgcvSkipWriteLocks")
+
+        file('versions.lock').text == lockFileContent
+        assert result.getOutput().contains("Skipped writing lock state")
+        assert !result.getOutput().contains("Finished writing lock state")
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
+    }
 }


### PR DESCRIPTION
## Before this PR
Depending on if GCV is invoked with `--write-locks`, the unifiedClasspath might get evaluated or not: 
https://github.com/palantir/gradle-consistent-versions/blob/5d28c1cb73d2d792b750900ac669c56ec7998c3c/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java#L276-L277

In some cases this can lead to different version constraints getting added depending on if `--write-locks` is used. As a result, other plugins that use the `--write-locks` flag (e.g. [sls-packaging `createManifest` task](https://github.com/palantir/sls-packaging)) might have different results depending on if `--write-locks` is used or not.

This manifests in bugs like `./gradlew createManifest` complaining about an outdated lock file but `./gradlew createManifest --write-locks` not updating the lock file.

## After this PR

Add the optional property `gcvSkipWriteLocks` that disables writing the GCV lock file. This is intended as a workaround to unblock plugins that also use the `--write-locks` flag and run into the above problems.

E.g. you can run `./gradlew createManifest --write-locks -PgcvSkipWriteLocks` to just update the createManifest lock file without updating the GCV lock file. 

==COMMIT_MSG==
Add property to skip writing lock file
==COMMIT_MSG==

## Possible downsides?
More like a hacky workaround to unblock people being affected by the inconsistent task output. However this change should only have a small-scale impact and we can revisit with a better solution if this becomes a bigger problem.