### PR TITLE
Delay configuration-on-demand-related errors until task execution

### DIFF
--- a/changelog/@unreleased/pr-725.v2.yml
+++ b/changelog/@unreleased/pr-725.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Fix the `checkUnusedConstraints` task to delay throwing an error about
+    incomplete configuration due to configure-on-demand until the task is actually
+    run. This fixes some situations in which the task is instantiated but not run.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/725

--- a/src/test/groovy/com/palantir/gradle/versions/ConfigurationOnDemandSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConfigurationOnDemandSpec.groovy
@@ -341,7 +341,7 @@ class ConfigurationOnDemandSpec extends IntegrationSpec {
 
         then:
         !result.output.contains('configuring upstream')
-        // The build actually fails during configuration, so there's no task outcome for :checkUnusedConstraints
+        result.task(':checkUnusedConstraints').outcome == TaskOutcome.FAILED
         result.output.contains("The gradle-consistent-versions checkUnusedConstraints task " +
                 "must have all projects configured to work accurately, but due to Gradle " +
                 "configuration-on-demand, not all projects were configured.")


### PR DESCRIPTION
This was causing an issue in a situation in which the task was
getting instantiated but not actually run.

## Before this PR
Using certain internal plugins could cause the `:checkUnusedConstraints` to be instantiated and this failure to happen, although it would be filtered out of the set of tests to run.

## After this PR
==COMMIT_MSG==
Fix the `checkUnusedConstraints` task to delay throwing an error about incomplete configuration due to configure-on-demand until the task is actually run. This fixes some situations in which the task is instantiated but not run.
==COMMIT_MSG==

This also makes it play nicely with `--continue`.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
None that I'm aware of.
