### PR TITLE
Add plugin and task for checking for new versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,14 @@ gradlePlugin {
             id = 'com.palantir.versions-props'
             implementationClass = 'com.palantir.gradle.versions.VersionsPropsPlugin'
         }
+        getVersions {
+            id = 'com.palantir.get-versions'
+            implementationClass = 'com.palantir.gradle.versions.GetVersionPlugin'
+        }
+        upgradeVersions {
+            id = 'com.palantir.check-versions'
+            implementationClass = 'com.palantir.gradle.versions.CheckVersionsPlugin'
+        }
     }
 }
 

--- a/src/main/java/com/palantir/gradle/versions/CheckNewVersionsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckNewVersionsTask.java
@@ -96,8 +96,7 @@ public class CheckNewVersionsTask extends DefaultTask {
 
     private Map<String, ResolvedDependency> getCurrentDependencyVersions(Configuration config) {
         Configuration resolvableOriginal = getResolvableCopy(config);
-        Map<String, ResolvedDependency> currentVersions = getResolvedVersions(resolvableOriginal);
-        return currentVersions;
+        return getResolvedVersions(resolvableOriginal);
     }
 
     private Map<String, ResolvedDependency> getLatestDependencyVersions(
@@ -111,8 +110,7 @@ public class CheckNewVersionsTask extends DefaultTask {
         resolvableLatest.getDependencies().addAll(latestDepsForConfig);
         // TODO(markelliot): we may want to find a way to tweak the resolution strategy so that forced module overrides
         //  still get a recommended upgrade
-        Map<String, ResolvedDependency> latestVersions = getResolvedVersions(resolvableLatest);
-        return latestVersions;
+        return getResolvedVersions(resolvableLatest);
     }
 
     private Configuration getResolvableCopy(Configuration config) {

--- a/src/main/java/com/palantir/gradle/versions/CheckNewVersionsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckNewVersionsTask.java
@@ -31,12 +31,13 @@ import org.gradle.api.tasks.TaskAction;
 import org.immutables.value.Value;
 
 public class CheckNewVersionsTask extends DefaultTask {
-
     private boolean collapseConfigurations = true;
 
     @TaskAction
     public void taskAction() {
         Map<String, Set<VersionUpgradeDetail>> upgradeRecs = getProject().getConfigurations().stream()
+                // make safe for use with gradle-consistent-versions
+                .filter(config -> !config.getName().startsWith("consistentVersions"))
                 .collect(Collectors.toMap(Configuration::getName, this::getUpgradesForConfiguration));
 
         if (upgradeRecs.values().stream().anyMatch(upgrades -> !upgrades.isEmpty())) {
@@ -104,7 +105,7 @@ public class CheckNewVersionsTask extends DefaultTask {
     }
 
     private Configuration getResolvableCopy(Configuration config) {
-        Configuration resolvableConfig = config.copyRecursive().setTransitive(false);
+        Configuration resolvableConfig = config.copy().setTransitive(false);
         resolvableConfig.setCanBeResolved(true);
         return resolvableConfig;
     }

--- a/src/main/java/com/palantir/gradle/versions/CheckNewVersionsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckNewVersionsTask.java
@@ -1,0 +1,94 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.LenientConfiguration;
+import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.specs.Specs;
+import org.gradle.api.tasks.TaskAction;
+
+public class CheckNewVersionsTask extends DefaultTask {
+
+    @TaskAction
+    public void taskAction() {
+        getProject().getConfigurations().forEach(config -> printLatestVersions(config, config.getName()));
+
+        // Suggest upgrades for plugins
+        Configuration pluginConfiguration = getProject().getBuildscript().getConfigurations().getByName("classpath");
+        printLatestVersions(pluginConfiguration, "<plugins>");
+    }
+
+    private void printLatestVersions(Configuration config, String configurationName) {
+        Configuration resolvableConfig = config.copyRecursive().setTransitive(false);
+        resolvableConfig.setCanBeResolved(true);
+        LenientConfiguration origLenient = resolvableConfig.getResolvedConfiguration().getLenientConfiguration();
+        Set<ResolvedDependency> originalDeps = origLenient.getFirstLevelModuleDependencies(Specs.SATISFIES_ALL);
+
+        Map<String, String> depToCurrentVersion = new HashMap<>();
+
+        Set<Dependency> latestDepsForConfig = originalDeps.stream().map(dep -> {
+                    String key = dep.getModuleGroup() + ":" + dep.getModuleName();
+                    depToCurrentVersion.put(key, dep.getModuleVersion());
+                    return getProject().getDependencies().create(key + ":+");
+                })
+                .collect(Collectors.toSet());
+
+        Configuration copy = config.copyRecursive().setTransitive(false);
+        copy.setCanBeResolved(true);
+        copy.getDependencies().clear();
+        // TODO(markelliot): we may want to find a way to tweak the resolution strategy so that forced module overrides
+        //  still get a recommended upgrade
+
+        copy.getDependencies().addAll(latestDepsForConfig);
+
+        LenientConfiguration lenient =
+                copy.getResolvedConfiguration().getLenientConfiguration();
+
+        Set<ResolvedDependency> resolvedDeps =
+                lenient.getFirstLevelModuleDependencies(Specs.SATISFIES_ALL);
+
+        List<String> upgradeRecs = resolvedDeps.stream().flatMap(recDep -> {
+            String key = recDep.getModuleGroup() + ":" + recDep.getModuleName();
+            String currentVersion = depToCurrentVersion.get(key);
+            if (recDep.getModuleVersion().equals(currentVersion)) {
+                return Stream.empty();
+            }
+            return Stream.of(key
+                    + " "
+                    + currentVersion
+                    + " -> "
+                    + recDep.getModuleVersion());
+        }).collect(Collectors.toList());
+
+        if (!upgradeRecs.isEmpty()) {
+            System.out.println("Dependency upgrades for project '"
+                    + getProject().getName()
+                    + "' configuration '"
+                    + configurationName + "':");
+            upgradeRecs.forEach(rec -> System.out.println(" - " + rec));
+        }
+    }
+}

--- a/src/main/java/com/palantir/gradle/versions/CheckVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckVersionsPlugin.java
@@ -1,0 +1,27 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class CheckVersionsPlugin implements Plugin<Project> {
+    @Override
+    public final void apply(Project project) {
+        project.getAllprojects().forEach(p -> p.getTasks().create("checkNewVersions", CheckNewVersionsTask.class));
+    }
+}

--- a/src/test/groovy/com/palantir/gradle/versions/CheckVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/CheckVersionsPluginIntegrationSpec.groovy
@@ -1,0 +1,132 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions
+
+import static com.palantir.gradle.versions.GradleTestVersions.GRADLE_VERSIONS
+import static com.palantir.gradle.versions.PomUtils.makePlatformPom
+
+import spock.lang.Unroll
+
+@Unroll
+class CheckVersionsPluginIntegrationSpec extends IntegrationSpec {
+
+    static def PLUGIN_NAME = "com.palantir.check-versions"
+
+    void setup() {
+        File mavenRepo = generateMavenRepo(
+                "ch.qos.logback:logback-classic:1.2.3 -> org.slf4j:slf4j-api:1.7.25",
+                "org.slf4j:slf4j-api:1.7.11",
+                "org.slf4j:slf4j-api:1.7.20",
+                "org.slf4j:slf4j-api:1.7.24",
+                "org.slf4j:slf4j-api:1.7.25",
+                "junit:junit:4.10",
+                "org:test-dep-that-logs:1.0 -> org.slf4j:slf4j-api:1.7.11"
+        )
+        makePlatformPom(mavenRepo, "org", "platform", "1.0")
+        
+        buildFile << """
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            plugins {
+                id '${PLUGIN_NAME}'
+                id 'com.palantir.versions-lock'
+                id 'com.palantir.get-versions'
+            }
+            allprojects {
+                repositories {
+                    maven { url "file:///${mavenRepo.getAbsolutePath()}" }
+                }
+                
+                task resolveConfigurations {
+                    doLast {
+                        if (pluginManager.hasPlugin('java')) {
+                            configurations.compileClasspath.resolve()
+                            configurations.runtimeClasspath.resolve()
+                        }
+                    }
+                }
+            }
+        """
+    }
+
+    private def standardSetup() {
+        buildFile << """
+            allprojects {
+                // using nebula in ':baz'
+                apply plugin: 'nebula.dependency-recommender'
+                apply plugin: 'com.palantir.get-versions'
+            }
+        """.stripIndent()
+
+         addSubproject('foo', '''
+            apply plugin: 'java'
+            dependencies {
+                implementation 'org.slf4j:slf4j-api:1.7.24'
+            }
+        '''.stripIndent())
+
+        addSubproject('bar', '''
+            apply plugin: 'java'
+            dependencies {
+                implementation "org.slf4j:slf4j-api:${project.bar_version}"
+            }
+        '''.stripIndent())
+        file("gradle.properties") << "bar_version=1.7.11"
+
+        addSubproject('baz', '''
+            apply plugin: 'java'
+            dependencies {
+                implementation "org.slf4j:slf4j-api"
+            }
+            dependencyRecommendations {
+                map recommendations: ['org.slf4j:slf4j-api': '1.7.20']
+            }
+        '''.stripIndent())
+
+        addSubproject('forced', '''
+            apply plugin: 'java'
+            dependencies {
+                implementation "org.slf4j:slf4j-api"
+            }
+            configurations.all {
+                resolutionStrategy {
+                    force "org.slf4j:slf4j-api:1.7.20"
+                }
+            }
+        '''.stripIndent())
+
+        file('versions.props') << 'org.slf4j:slf4j-api = 1.7.24'
+    }
+
+    def '#gradleVersionNumber: checkNewVersions discovers and prints new versions'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+        standardSetup()
+
+        expect:
+        def result = runTasks('checkNewVersions', '--write-locks')
+        // TODO(markelliot): validate output
+        println result.output
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
+    }
+
+}


### PR DESCRIPTION
Pushing up this PR for discussion before getting deeper into functionality or tests.


## Before this PR
gcv enables setting of and locking versions per props and config files, but there's no
facility for detecting when to apply upgrades. While not strictly required for gcv, it
would be convenient in the context of managing versions to report what upgrades may be
applied.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add task for checking for new versions of dependencies
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
