### PR TITLE
Revert "Provide constraints for java libraries in the same repo (#815)"

### DIFF
--- a/changelog/@unreleased/pr-821.v2.yml
+++ b/changelog/@unreleased/pr-821.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Revert "Provide constraints for java libraries in the same repo (#815)"
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/821

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -354,21 +354,18 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         buildFile << """
             allprojects {
                 apply plugin: 'java'
-            }
-        """.stripIndent()
-
-        String publish = """
-            apply plugin: 'maven-publish'
-            publishing.publications {
-                maven(MavenPublication) {
-                    from components.java
+                apply plugin: 'maven-publish'
+                
+                publishing.publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
                 }
             }
         """.stripIndent()
 
         addSubproject('foo', """
             apply plugin: 'java'
-            $publish
             dependencies {
                 implementation 'ch.qos.logback:logback-classic'
             }

--- a/src/test/groovy/com/palantir/gradle/versions/MetadataFile.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/MetadataFile.groovy
@@ -25,13 +25,13 @@ import groovy.transform.ToString
  * Gradle Metadata File</a>.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ToString(includePackage = false)
+@ToString
 @EqualsAndHashCode
 class MetadataFile {
     Set<Variant> variants
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    @ToString(includePackage = false)
+    @ToString
     @EqualsAndHashCode
     static class Variant {
         String name
@@ -39,7 +39,7 @@ class MetadataFile {
         Set<Dependency> dependencyConstraints
     }
 
-    @ToString(includePackage = false)
+    @ToString
     @EqualsAndHashCode
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class Dependency {

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -857,29 +857,23 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         buildFile << """
             allprojects {
                 apply plugin: 'java'
-            }
-        """.stripIndent()
-
-        String publish = """
-            apply plugin: 'maven-publish'
-            group = 'com.palantir.published-constraints'
-            version = '1.2.3'
-            publishing.publications {
-                maven(MavenPublication) {
-                    from components.java
+                apply plugin: 'maven-publish'
+                
+                publishing.publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
                 }
             }
         """.stripIndent()
 
         addSubproject('foo', """
-            $publish
             dependencies {
                 implementation 'ch.qos.logback:logback-classic:1.2.3'
             }
         """.stripIndent())
 
         addSubproject('bar', """
-            $publish
             dependencies {
                 implementation 'junit:junit:4.10'
             }
@@ -908,14 +902,6 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
                 group: 'org.slf4j',
                 module: 'slf4j-api',
                 version: [requires: '1.7.25'])
-        def fooDep = new MetadataFile.Dependency(
-                group: 'com.palantir.published-constraints',
-                module: 'foo',
-                version: [requires: '1.2.3'])
-        def barDep = new MetadataFile.Dependency(
-                group: 'com.palantir.published-constraints',
-                module: 'bar',
-                version: [requires: '1.2.3'])
 
         then: "foo's metadata file has the right dependency constraints"
         def fooMetadataFilename = new File(projectDir, "foo/build/publications/maven/module.json")
@@ -923,13 +909,13 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         fooMetadata.variants == [
                 new MetadataFile.Variant(
-                        name: 'runtimeElements',
-                        dependencies: [logbackDep],
-                        dependencyConstraints: [barDep, junitDep, logbackDep, slf4jDep]),
-                new MetadataFile.Variant(
                         name: 'apiElements',
                         dependencies: null,
-                        dependencyConstraints: [barDep, junitDep, logbackDep, slf4jDep])
+                        dependencyConstraints: [junitDep, logbackDep, slf4jDep]),
+                new MetadataFile.Variant(
+                        name: 'runtimeElements',
+                        dependencies: [logbackDep],
+                        dependencyConstraints: [junitDep, logbackDep, slf4jDep]),
         ] as Set
 
         and: "bar's metadata file has the right dependency constraints"
@@ -938,13 +924,13 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         barMetadata.variants == [
                 new MetadataFile.Variant(
-                        name: 'runtimeElements',
-                        dependencies: [junitDep],
-                        dependencyConstraints: [fooDep, junitDep, logbackDep, slf4jDep]),
-                new MetadataFile.Variant(
                         name: 'apiElements',
                         dependencies: null,
-                        dependencyConstraints: [fooDep, junitDep, logbackDep, slf4jDep]),
+                        dependencyConstraints: [junitDep, logbackDep, slf4jDep]),
+                new MetadataFile.Variant(
+                        name: 'runtimeElements',
+                        dependencies: [junitDep],
+                        dependencyConstraints: [junitDep, logbackDep, slf4jDep]),
         ] as Set
 
         where:


### PR DESCRIPTION
## Before this PR
In https://github.com/palantir/gradle-consistent-versions/pull/815, we started adding constraints for published java-libraries in the same repo.

Multiple projects are failing to resolve transitive project dependencies after picking up these changes. The two scenarios encountered so fat:
* Projects producing a bundle in which they explicitly want to depend on a previous publish of a sub-project dependency.
* Projects that pull in a sub-project dependency transitively.

In both cases, Gradle adds a constraint on the sub-project dependency, bumping the version to the local project version. However it then fails to resolve the sub-project dependency as it tries to look-up the local project version in external repositories.

*Edit:* I looked a bit more into the failures and I think the issues we saw are all related to projects having cyclic dependencies. E.g. in one example we had a cyclic transitive dependency of `project -> external-dep -> project`. Previously, this resolved fine because the transitive `project` dep could be resolved using a previously published version. However now that we added local project constraints, the version of the transitive `project` dep gets bumped to the local project version which has not been build yet and thus cannot be resolved.

## After this PR

Reverting for now. We still want the overall outcome but have to figure out a solution for these edge cases.

==COMMIT_MSG==
Revert "Provide constraints for java libraries in the same repo (#815)"
==COMMIT_MSG==
