### PR TITLE
Provide constraints for java libraries in the same repo, behind experimental feature flag

### DIFF
--- a/changelog/@unreleased/pr-825.v2.yml
+++ b/changelog/@unreleased/pr-825.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: 'Provide constraints for java libraries in the same repo, behind experimental
+    feature flag: `com.palantir.gradle.versions.publishLocalConstraints`'
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/825

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -94,6 +94,10 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.provider.Property;
+import org.gradle.api.publish.Publication;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.ivy.IvyPublication;
+import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
@@ -899,8 +903,21 @@ public class VersionsLockPlugin implements Plugin<Project> {
         List<DependencyConstraint> publishableConstraints = constructPublishableConstraintsFromLockFile(
                 gradleLockfile, rootProject.getDependencies().getConstraints()::create);
 
-        rootProject.allprojects(subproject -> configureUsingConstraints(
-                subproject, locksDependency, publishableConstraints, lockedConfigurations.get(subproject)));
+        rootProject.allprojects(subproject -> {
+            // Avoid including the current project as a constraint -- it must already be present to provide constraints
+            List<DependencyConstraint> localProjectConstraints = constructPublishableConstraintsFromLocalProjects(
+                    subproject, rootProject.getDependencies().getConstraints()::create);
+            ImmutableList<DependencyConstraint> publishableConstraintsForSubproject =
+                    ImmutableList.<DependencyConstraint>builder()
+                            .addAll(localProjectConstraints)
+                            .addAll(publishableConstraints)
+                            .build();
+            configureUsingConstraints(
+                    subproject,
+                    locksDependency,
+                    publishableConstraintsForSubproject,
+                    lockedConfigurations.get(subproject));
+        });
     }
 
     private static void configureUsingConstraints(
@@ -1042,6 +1059,68 @@ public class VersionsLockPlugin implements Plugin<Project> {
                     constraint.because("Computed from com.palantir.consistent-versions' versions.lock");
                 }))
                 .collect(Collectors.toList());
+    }
+
+    private static List<DependencyConstraint> constructPublishableConstraintsFromLocalProjects(
+            Project currentProject, DependencyConstraintCreator constraintCreator) {
+        // Include all other libraries published from the same repository
+        return currentProject.getRootProject().getAllprojects().stream()
+                .filter(project -> !currentProject.equals(project))
+                .filter(VersionsLockPlugin::isJavaLibrary)
+                .map(libraryProject -> constraintCreator.create(
+                        libraryProject, constraint -> constraint.because("Library published from the same project")))
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isJavaLibrary(Project project) {
+        if (project.getPluginManager().hasPlugin("nebula.maven-publish")) {
+            // 'nebula.maven-publish' creates publications lazily which causes inconsistencies based
+            // on ordering.
+            log.debug(
+                    "Project '{}' is considered a library because the 'nebula.maven-publish' plugin is applied",
+                    project.getDisplayName());
+            return true;
+        }
+        PublishingExtension publishing = project.getExtensions().findByType(PublishingExtension.class);
+        if (publishing == null) {
+            log.debug(
+                    "Project '{}' is considered a distribution, not a library, because "
+                            + "it doesn't define any publishing extensions",
+                    project.getDisplayName());
+            return false;
+        }
+        ImmutableList<String> jarPublications = publishing.getPublications().stream()
+                .filter(pub -> isLibraryPublication(project, pub))
+                .map(Named::getName)
+                .collect(ImmutableList.toImmutableList());
+        if (jarPublications.isEmpty()) {
+            log.debug(
+                    "Project '{}' is not considered a library because it does not publish jars",
+                    project.getDisplayName());
+            return false;
+        }
+        log.debug(
+                "Project '{}' is considered a library because it publishes jars: {}",
+                project.getDisplayName(),
+                jarPublications);
+        return true;
+    }
+
+    private static boolean isLibraryPublication(Project project, Publication publication) {
+        if (publication instanceof MavenPublication) {
+            MavenPublication mavenPublication = (MavenPublication) publication;
+            return mavenPublication.getArtifacts().stream().anyMatch(artifact -> "jar".equals(artifact.getExtension()));
+        }
+        if (publication instanceof IvyPublication) {
+            IvyPublication ivyPublication = (IvyPublication) publication;
+            return ivyPublication.getArtifacts().stream().anyMatch(artifact -> "jar".equals(artifact.getExtension()));
+        }
+        log.warn(
+                "Unknown publication '{}' of type '{}'. Assuming project {} is a library",
+                publication,
+                publication.getClass().getName(),
+                project.getName());
+        return true;
     }
 
     public static boolean shouldWriteLocks(Project project) {

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -354,18 +354,21 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         buildFile << """
             allprojects {
                 apply plugin: 'java'
-                apply plugin: 'maven-publish'
-                
-                publishing.publications {
-                    maven(MavenPublication) {
-                        from components.java
-                    }
+            }
+        """.stripIndent()
+
+        String publish = """
+            apply plugin: 'maven-publish'
+            publishing.publications {
+                maven(MavenPublication) {
+                    from components.java
                 }
             }
         """.stripIndent()
 
         addSubproject('foo', """
             apply plugin: 'java'
+            $publish
             dependencies {
                 implementation 'ch.qos.logback:logback-classic'
             }

--- a/src/test/groovy/com/palantir/gradle/versions/MetadataFile.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/MetadataFile.groovy
@@ -25,13 +25,13 @@ import groovy.transform.ToString
  * Gradle Metadata File</a>.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ToString
+@ToString(includePackage = false)
 @EqualsAndHashCode
 class MetadataFile {
     Set<Variant> variants
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    @ToString
+    @ToString(includePackage = false)
     @EqualsAndHashCode
     static class Variant {
         String name
@@ -39,7 +39,7 @@ class MetadataFile {
         Set<Dependency> dependencyConstraints
     }
 
-    @ToString
+    @ToString(includePackage = false)
     @EqualsAndHashCode
     @JsonIgnoreProperties(ignoreUnknown = true)
     static class Dependency {

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -43,6 +43,8 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
                 "org:test-dep-that-logs:1.0 -> org.slf4j:slf4j-api:1.7.11"
         )
         makePlatformPom(mavenRepo, "org", "platform", "1.0")
+        // Test with local constraints enabled
+        file('gradle.properties') << 'com.palantir.gradle.versions.publishLocalConstraints = true'
         
         buildFile << """
             buildscript {


### PR DESCRIPTION
## Before this PR
Publications from a single repo could be resolved to different versions -- e.g. higher version API than implementation.
The previous attempt to merge this resulted in issues handling circular dependencies, we we're hiding the feature behind a flag until we've been able to resolve the edge cases.

## After this PR
==COMMIT_MSG==
Provide constraints for java libraries in the same repo, behind experimental feature flag: `com.palantir.gradle.versions.publishLocalConstraints`
==COMMIT_MSG==

