### PR TITLE
Include annotation processor configuration in locks

### DIFF
--- a/changelog/@unreleased/pr-862.v2.yml
+++ b/changelog/@unreleased/pr-862.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The `annotationProcessor` configuration is now included in the locked
+    configurations.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/862

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockExtension.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockExtension.java
@@ -99,6 +99,7 @@ public class VersionsLockExtension {
         }
 
         public void from(SourceSet sourceSet) {
+            from(sourceSet.getAnnotationProcessorConfigurationName());
             from(sourceSet.getCompileClasspathConfigurationName());
             from(sourceSet.getRuntimeClasspathConfigurationName());
         }

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -1011,6 +1011,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
     private static ImmutableSet<Configuration> getConfigurationsForSourceSet(Project project, SourceSet sourceSet) {
         return ImmutableSet.of(
+                project.getConfigurations().getByName(sourceSet.getAnnotationProcessorConfigurationName()),
                 project.getConfigurations().getByName(sourceSet.getCompileClasspathConfigurationName()),
                 project.getConfigurations().getByName(sourceSet.getRuntimeClasspathConfigurationName()));
     }


### PR DESCRIPTION
Typically, annotation processors have a corresponding annotation library that needs to be present on the compile classpath. When the annotation processor and annotation library versions do not match, errors can occur.

For example, when upgrading [gradle-baseline](https://github.com/palantir/gradle-baseline) from 0.65.0 to 0.66.0 the version of `org.immutable:value` used by `baseline-error-prone` changed from 2.8.8 to 2.9.0 because of https://github.com/palantir/gradle-baseline/pull/2060. If consumers are still using immutables 2.8.8, then the `compileClasspath` configuration will be using 2.8.8, but the `annotationProcessor` configuration will be using 2.9.0. The `annotationProcessor` configuration uses [Gradle conflict resolution](https://docs.gradle.org/current/userguide/dependency_resolution.html), which will select 2.9.0 (from `baseline-error-prone`) over 2.8.8 (from `versions.props`).

```
$ ./gradlew dependencyInsight --configuration annotationProcessor --dependency org.immutables

> Task :granular-permissions:dependencyInsight
org.immutables:value:2.9.0
   variant "runtime" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-runtime
      org.gradle.libraryelements     = jar
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
   ]
   Selection reasons:
      - By constraint : belongs to platform org.immutables:_:2.9.0
      - By conflict resolution : between versions 2.9.0 and 2.8.8

org.immutables:value:2.9.0
\--- com.palantir.baseline:baseline-error-prone:4.66.0
     \--- annotationProcessor

org.immutables:value:2.8.8 -> 2.9.0
\--- annotationProcessor
```

As a result, compilation fails with the following error:
```
warning: The version of the Immutables annotation on the classpath has incompatible differences from the Immutables annotation processor used. Various problems might occur, like this one: java.lang.NullPointerException: default attribute 'toBuilder'
error: org.immutables.value.internal.$processor$.$Processor threw java.lang.NullPointerException: default attribute 'toBuilder'
```