### PR TITLE
Revert Annotation Processor Inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ com.github.zafarkhaja:java-semver:0.9.0 (1 constraints: c315c0d2)
 com.jayway.awaitility:awaitility:1.6.5 (1 constraints: c615c1d2)
 ```
 
-The lockfile sources production dependencies from the _annotationProcessor_, _compileClasspath_, and _runtimeClasspath_ configurations, and
-test dependencies from the annotation processor, compile classpath, and runtime classpath of any source set that ends in test (e.g. `test`, `integrationTest`,
+The lockfile sources production dependencies from the _compileClasspath_ and _runtimeClasspath_ configurations, and
+test dependencies from the compile/runtime classpaths of any source set that ends in test (e.g. `test`, `integrationTest`,
 `eteTest`).
 
 There is a `verifyLocks` task (automatically run as part of `check`) that will ensure `versions.lock` is still consistent

--- a/changelog/@unreleased/pr-871.v2.yml
+++ b/changelog/@unreleased/pr-871.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Annotation processors are no longer included in locked configurations
+    by default
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/871

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockExtension.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockExtension.java
@@ -99,7 +99,6 @@ public class VersionsLockExtension {
         }
 
         public void from(SourceSet sourceSet) {
-            from(sourceSet.getAnnotationProcessorConfigurationName());
             from(sourceSet.getCompileClasspathConfigurationName());
             from(sourceSet.getRuntimeClasspathConfigurationName());
         }

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -1011,7 +1011,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
     private static ImmutableSet<Configuration> getConfigurationsForSourceSet(Project project, SourceSet sourceSet) {
         return ImmutableSet.of(
-                project.getConfigurations().getByName(sourceSet.getAnnotationProcessorConfigurationName()),
                 project.getConfigurations().getByName(sourceSet.getCompileClasspathConfigurationName()),
                 project.getConfigurations().getByName(sourceSet.getRuntimeClasspathConfigurationName()));
     }


### PR DESCRIPTION
This fixes an issue in which error-prone annotations would transitively cause dependent projects to use newer-than-expected error-prone releases.
In general locking annotation processors is desirable, however we must find a way to decouple compiler plugins from annotation processors before we can roll this out successfully.

==COMMIT_MSG==
Annotation processors are no longer included in locked configurations by default
==COMMIT_MSG==
