### PR TITLE
Reduce noisy logs from info to debug

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -613,7 +613,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
             Configuration targetConf = getTargetConfiguration(dependencySet, projectDependency);
 
-            log.info(
+            log.debug(
                     "Found legacy project dependency (with target configuration): {} -> {}",
                     dependencySet,
                     formatProjectDependency(projectDependency));
@@ -643,8 +643,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
             // Update state about what we've seen
             copiedConfigurationsCache.put(targetConf, copiedConf.getName());
 
-            if (log.isInfoEnabled()) {
-                log.info(
+            if (log.isDebugEnabled()) {
+                log.debug(
                         "Recursively copied {}'s '{}' configuration, which has\n"
                                 + " - dependencies: {}\n"
                                 + " - constraints: {}",

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -613,10 +613,12 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
             Configuration targetConf = getTargetConfiguration(dependencySet, projectDependency);
 
-            log.debug(
-                    "Found legacy project dependency (with target configuration): {} -> {}",
-                    dependencySet,
-                    formatProjectDependency(projectDependency));
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "Found legacy project dependency (with target configuration): {} -> {}",
+                        dependencySet,
+                        formatProjectDependency(projectDependency));
+            }
 
             if (copiedConfigurationsCache.containsKey(targetConf)) {
                 String copiedConf = copiedConfigurationsCache.get(targetConf);


### PR DESCRIPTION
I frequently use `--info` to debug Gradle build issues. These two log lines are quite noisy and produce a ton of output. They don't seem particularly relevant in most cases, so this PR lowers the level to debug.