### PR TITLE
Allow passing multiple hashes to the `why` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ This is effectively just a more concise version of `dependencyInsight`:
 ./gradlew  dependencyInsight --configuration unifiedClasspath --dependency jackson-databind
 ```
 
+You can check multiple dependencies at once by passing multiple comma-delimited hash values, e.g.
+`./gradlew why --hash a60c3ce8,400d4d2a`.
+
 ## ./gradlew checkUnusedConstraints
 `checkUnusedConstraints` prevents unnecessary constraints from accruing in your `versions.props` file. Run
 `./gradlew checkUnusedConstraints --fix` to automatically remove any unused constraints from your props file.

--- a/changelog/@unreleased/pr-916.v2.yml
+++ b/changelog/@unreleased/pr-916.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The `--hash` argument of the `why` task now accepts multiple, comma-separated
+    hashes.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/916


### PR DESCRIPTION
Running this task multiple times can be somewhat slow in large
repositories. Allow passing in multiple, comma-delimited hashes
to the `--hash` argument to receive information about multiple
dependencies in a single run.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
There's no way to ask the `why` task about multiple dependencies in a single Gradle run -- you'd have to ask in consecutive runs, which incurs the cost of Gradle starting a run and gathering information.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The `--hash` argument of the `why` task now accepts multiple, comma-separated hashes.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->