### PR TITLE
Support lenient versions in GCV to enable Jakarta bridge migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,20 @@ Direct dependencies are specified in a top level `versions.props` file and then 
     1. An evolution of `nebula.dependency-recommender`
 1. [Concepts](#concepts)
     1. versions.props: lower bounds for dependencies
-    1. versions.lock: compact representation of your prod classpath
-    1. ./gradlew why
-    1. ./gradlew checkUnusedConstraints
-    1. getVersion
-    1. BOMs
-    1. Specifying exact versions
-    1. Downgrading things
-    1. Common workflow: SLF4J
-    1. Common workflow: dependencySubstitution
-    1. Common workflow: internal test utility projects
-    1. Resolving dependencies at configuration time is banned
-    1. Known limitation: root project must have a unique name
-    1. Scala
+    2. versions.lock: compact representation of your prod classpath
+    3. ./gradlew why
+    4. ./gradlew checkUnusedConstraints
+    5. getVersion
+    6. BOMs
+    7. Specifying exact versions
+    8. Downgrading things
+    9. Common workflow: SLF4J
+    10. Common workflow: dependencySubstitution
+    11. Common workflow: internal test utility projects
+    12. Edge case workflow: run with different sub project versions
+    13. Resolving dependencies at configuration time is banned
+    14. Known limitation: root project must have a unique name
+    15. Scala
 1. [Migration](#migration)
     1. How to make this work with Baseline
     1. `dependencyRecommendations.getRecommendedVersion` -> `getVersion`
@@ -307,6 +308,39 @@ versionsLock {
     testProject()
 }
 ```
+
+### Edge case workflow: run with different sub project versions
+
+**NB:** This work around should only be used for projects which need to support multiple
+different versions of libraries running across disjoint subprojects. It is documented
+for completeness.
+
+If your project has an expressed need to support multiple different versions of libraries between
+subprojects which are not dependent on each other, then you can relax the dependency constraints
+enforced by this plugin from `strictly` to `prefer`, this enables one project to rely on the versions
+locked in `versions.lock`, and another project to force a different version:
+
+```groovy
+dependencies {
+    api "org.glassfish.jersey.core:jersey-server", {
+        version {
+            strictly '2.22.2'
+        }
+    }
+}
+```
+
+To enter this mode, apply the following to your root project:
+
+```groovy
+versionsLock {
+    lenientVersions = true
+}
+```
+
+This will allow subprojects to selectively override the `versions.lock` version. See the
+[gradle documentation on rich versions](https://docs.gradle.org/current/userguide/rich_versions.html)
+for details.
 
 ### Resolving dependencies at configuration time is banned
 In order for this plugin to function, we must be able to guarantee that no dependencies are resolved at configuration time.  Gradle already [recommends this](https://guides.gradle.org/performance/#don_t_resolve_dependencies_at_configuration_time) but gradle-consistent-versions enforces it.

--- a/changelog/@unreleased/pr-968.v2.yml
+++ b/changelog/@unreleased/pr-968.v2.yml
@@ -1,0 +1,22 @@
+type: improvement
+improvement:
+  description: |-
+    Support lenient versions in GCV to enable Jakarta bridge migrations
+
+
+    In order to support libraries like tracing-java which need
+    both javax libraries and jakarta libraries, we need to have some
+    way of hosting both in the same repository, but not having GCV
+    force our versions of all subprojects up to that version as well.
+
+    This introduces a mode in GCV (which is very much frowned upon
+    anyone using), which instead of forcing strict versions from the
+    versions.lock file, instead makes them prefer, this then lets
+    subprojects force the version to strict, which overrides any
+    past or future version constraints.
+
+    I'm not super happy with this solution since it does violate some
+    of the principles of GCV, but the problem we're trying to solve with
+    the Jakarta migration is very much non-compliant.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/968

--- a/src/main/java/com/palantir/gradle/versions/DependencyConstraintCreator.java
+++ b/src/main/java/com/palantir/gradle/versions/DependencyConstraintCreator.java
@@ -18,12 +18,43 @@ package com.palantir.gradle.versions;
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.MutableVersionConstraint;
+import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 
-@FunctionalInterface
 interface DependencyConstraintCreator {
     default DependencyConstraint create(Object notation) {
         return create(notation, _constraint -> {});
     }
 
     DependencyConstraint create(Object notation, Action<? super DependencyConstraint> action);
+
+    void lockVersion(MutableVersionConstraint versionConstraint, String version);
+
+    static DependencyConstraintCreator strict(DependencyConstraintHandler handler) {
+        return new DependencyConstraintCreator() {
+            @Override
+            public DependencyConstraint create(Object notation, Action<? super DependencyConstraint> action) {
+                return handler.create(notation, action);
+            }
+
+            @Override
+            public void lockVersion(MutableVersionConstraint versionConstraint, String version) {
+                versionConstraint.strictly(version);
+            }
+        };
+    }
+
+    static DependencyConstraintCreator required(DependencyConstraintHandler handler) {
+        return new DependencyConstraintCreator() {
+            @Override
+            public DependencyConstraint create(Object notation, Action<? super DependencyConstraint> action) {
+                return handler.create(notation, action);
+            }
+
+            @Override
+            public void lockVersion(MutableVersionConstraint versionConstraint, String version) {
+                versionConstraint.prefer(version);
+            }
+        };
+    }
 }

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockExtension.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockExtension.java
@@ -30,6 +30,8 @@ public class VersionsLockExtension {
     private final Project project;
     private final SetProperty<String> productionConfigurations;
     private final SetProperty<String> testConfigurations;
+
+    private final Property<Boolean> lenientVersions;
     private final ScopeConfigurer productionConfigurer;
     private final ScopeConfigurer testConfigurer;
     private final Property<Boolean> useJavaPluginDefaults;
@@ -39,11 +41,14 @@ public class VersionsLockExtension {
         this.project = project;
         this.useJavaPluginDefaults =
                 project.getObjects().property(Boolean.class).convention(true);
+        this.lenientVersions = project.getObjects().property(Boolean.class).convention(false);
         this.productionConfigurations =
                 project.getObjects().setProperty(String.class).empty();
         this.testConfigurations = project.getObjects().setProperty(String.class).empty();
         this.productionConfigurer = new ScopeConfigurer(productionConfigurations);
         this.testConfigurer = new ScopeConfigurer(testConfigurations);
+
+        this.lenientVersions.finalizeValueOnRead();
     }
 
     public final void production(Action<ScopeConfigurer> action) {
@@ -56,6 +61,10 @@ public class VersionsLockExtension {
 
     public final void disableJavaPluginDefaults() {
         useJavaPluginDefaults.set(false);
+    }
+
+    public final Property<Boolean> getLenientVersions() {
+        return lenientVersions;
     }
 
     public final void testProject() {

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -100,7 +100,11 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                 conf.setCanBeConsumed(true);
                 conf.setVisible(false);
 
-                addVersionsPropsConstraints(project.getDependencies().getConstraints()::create, conf, versionsProps);
+                addVersionsPropsConstraints(
+                        DependencyConstraintCreator.strict(
+                                project.getDependencies().getConstraints()),
+                        conf,
+                        versionsProps);
             });
         }
 

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -233,7 +233,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
             }
         """.stripIndent()
 
-        file('versions.props') << 'org.slf4j:* = 1.7.25'
+        file('versions.props') << 'junit:* = 4.10'
 
         expect:
         runTasks('--write-locks')

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -225,7 +225,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         buildFile << """
             apply plugin: 'java'
             dependencies {
-                implementation 'junit:junit'
+                implementation 'org.slf4j:slf4j-api'
             }
             
             versionsLock {
@@ -233,7 +233,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
             }
         """.stripIndent()
 
-        file('versions.props') << 'junit:* = 4.10'
+        file('versions.props') << 'org.slf4j:* = 1.7.25'
 
         expect:
         runTasks('--write-locks')

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -239,9 +239,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         runTasks('--write-locks')
         def expected = """\
             # Run ./gradlew --write-locks to regenerate this file
-             
-            [Test dependencies]
-            junit:junit:4.10 (1 constraints: d904fd30)
+            org.slf4j:slf4j-api:1.7.25 (1 constraints: 4105483b)
         """.stripIndent()
         file('versions.lock').text == expected
 

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -218,6 +218,37 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GRADLE_VERSIONS
     }
 
+    def "#gradleVersionNumber: isLenientVersions works"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
+        buildFile << """
+            apply plugin: 'java'
+            dependencies {
+                implementation 'junit:junit'
+            }
+            
+            versionsLock {
+                lenientVersions = true
+            }
+        """.stripIndent()
+
+        file('versions.props') << 'org.slf4j:* = 1.7.25'
+
+        expect:
+        runTasks('--write-locks')
+        def expected = """\
+            # Run ./gradlew --write-locks to regenerate this file
+             
+            [Test dependencies]
+            junit:junit:4.10 (1 constraints: d904fd30)
+        """.stripIndent()
+        file('versions.lock').text == expected
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
+    }
+
     def "#gradleVersionNumber: virtual platform is respected across projects"() {
         setup:
         gradleVersion = gradleVersionNumber


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We were unable to run subprojects with different versions from the `versions.lock`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support lenient versions in GCV to enable Jakarta bridge migrations


In order to support libraries like tracing-java which need
both javax libraries and jakarta libraries, we need to have some
way of hosting both in the same repository, but not having GCV
force our versions of all subprojects up to that version as well.

This introduces a mode in GCV (which is very much frowned upon
anyone using), which instead of forcing strict versions from the
versions.lock file, instead makes them prefer, this then lets
subprojects force the version to strict, which overrides any
past or future version constraints.

I'm not super happy with this solution since it does violate some
of the principles of GCV, but the problem we're trying to solve with
the Jakarta migration is very much non-compliant.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

Anyone but a small handful of projects uses this new feature.

