### PR TITLE
Improvement: Clarify instructions on how to automate removal of unused pins

### DIFF
--- a/changelog/@unreleased/pr-1007.v2.yml
+++ b/changelog/@unreleased/pr-1007.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Clarify instructions on how to automate removal of unused pins
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1007

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
@@ -135,7 +135,7 @@ public class CheckUnusedConstraintsTask extends DefaultTask {
         throw new RuntimeException("There are unused pins in your versions.props: \n"
                 + unusedConstraints
                 + "\n\n"
-                + "Rerun with --fix to remove them.");
+                + "Run ./gradlew checkUnusedConstraints --fix to remove them.");
     }
 
     private static void writeVersionsProps(File propsFile, Set<String> unusedConstraints) {


### PR DESCRIPTION
## Before this PR
If one ran `./gradlew check` and got this error, then ran `./gradlew check --fix`, they'd get:
```
* What went wrong:
Problem configuring task :check from command line.
> Unknown command-line option '--fix'.
```
Gradle requires you to run that task directly for the command-line option to successfully work.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Clarify instructions on how to automate removal of unused pins
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

