### PR TITLE
Improvement: Add gradle 8 compatibility

### DIFF
--- a/changelog/@unreleased/pr-1060.v2.yml
+++ b/changelog/@unreleased/pr-1060.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add gradle 8 compatibility
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1060

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -661,8 +661,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
             copiedConf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
             // Must set this because we depend on this configuration when resolving unifiedClasspath.
             copiedConf.setCanBeConsumed(true);
-            // But this should never be resolved! (it will most likely fail to given the usage above)
-            copiedConf.setCanBeResolved(false);
             // Since we only depend on these from the same project (via CONSISTENT_VERSIONS_PRODUCTION or
             // CONSISTENT_VERSIONS_TEST), we shouldn't allow them to be visible outside this project.
             copiedConf.setVisible(false);

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -115,34 +115,6 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    // TODO(dsanduleac): should remove this since this functionality doesn't fully work anyway, and we are
-    //   actively encouraging people to stop resolving the deprecated configurations `compile` and `runtime`.
-    def '#gradleVersionNumber: can resolve all configurations like compile with version coming only from versions props'() {
-        setup:
-        gradleVersion = gradleVersionNumber
-
-        file('versions.props') << """
-            org.slf4j:slf4j-api = 1.7.22
-        """.stripIndent()
-
-        buildFile << """
-            apply plugin: 'java'
-            dependencies {
-                implementation "org.slf4j:slf4j-api"
-            }
-        """.stripIndent()
-
-        when:
-        runTasks('--write-locks')
-
-        then:
-        // Ensures that configurations like 'compile' are resolved and their dependencies have versions
-        runTasks('--warning-mode=none', 'resolveConfigurations')
-
-        where:
-        gradleVersionNumber << GRADLE_VERSIONS
-    }
-
     def "#gradleVersionNumber: locks are consistent whether or not we do --write-locks for glob-forced direct dependency"() {
         setup:
         gradleVersion = gradleVersionNumber

--- a/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
+++ b/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
@@ -16,12 +16,11 @@
 
 package com.palantir.gradle.versions;
 
-import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 public final class GradleTestVersions {
     private GradleTestVersions() {}
 
     public static final List<String> GRADLE_VERSIONS =
-            ImmutableList.of(VersionsLockPlugin.MINIMUM_GRADLE_VERSION.getVersion(), "6.9", "7.1.1");
+            List.of(VersionsLockPlugin.MINIMUM_GRADLE_VERSION.getVersion(), "6.9", "7.1.1", "8.1.1");
 }


### PR DESCRIPTION
## Before this PR
We couldn't run against gradle 8

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support gradle 8
==COMMIT_MSG==

There's deprecations to be resolved before gradle 9. I think they boil down to completely purging runtime and compile classpath configurations from referneces and using apiElements and runtimeElements, however, in my limited attempts naive swap didn't work so it might need deeper investigation

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

