### PR TITLE
Fix publish to gradle plugin portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,19 +91,21 @@ gradlePlugin {
         consistentVersions {
             id = 'com.palantir.consistent-versions'
             implementationClass = 'com.palantir.gradle.versions.ConsistentVersionsPlugin'
-            description = 'Compact, constraint-friendly lockfiles for your dependencies'
             displayName = 'Compact, constraint-friendly lockfiles for your dependencies'
+            description = displayName
             tags.set(['versions'])
         }
         versionsLock {
             id = 'com.palantir.versions-lock'
             implementationClass = 'com.palantir.gradle.versions.VersionsLockPlugin'
             displayName = 'Compact, constraint-friendly lockfiles for your dependencies'
+            description = displayName
         }
         versionsProps {
             id = 'com.palantir.versions-props'
             implementationClass = 'com.palantir.gradle.versions.VersionsPropsPlugin'
             displayName = 'Inject version constraints into every configuration in your projects'
+            description = displayName
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -98,10 +98,12 @@ gradlePlugin {
         versionsLock {
             id = 'com.palantir.versions-lock'
             implementationClass = 'com.palantir.gradle.versions.VersionsLockPlugin'
+            displayName = 'Compact, constraint-friendly lockfiles for your dependencies'
         }
         versionsProps {
             id = 'com.palantir.versions-props'
             implementationClass = 'com.palantir.gradle.versions.VersionsPropsPlugin'
+            displayName = 'Inject version constraints into every configuration in your projects'
         }
     }
 }

--- a/changelog/@unreleased/pr-1077.v2.yml
+++ b/changelog/@unreleased/pr-1077.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix publishing to gradle plugins portal.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1077


### PR DESCRIPTION
## Before this PR
GCV 2.13.0 is not available in the gradle plugin portal - [the latest version is 2.12.0](https://plugins.gradle.org/plugin/com.palantir.consistent-versions).

There was [a publish failure for 2.13.0](https://app.circleci.com/pipelines/github/palantir/gradle-consistent-versions/2968/workflows/491ef2c9-cd57-404c-b0df-fc8909590f0c/jobs/13231):

```
Caused by: java.lang.IllegalArgumentException: Plugin 'versionsLock' has no 'displayName' property set
	at com.gradle.publish.AbstractConfigValidator.validateProperty(AbstractConfigValidator.java:137)
	at com.gradle.publish.AbstractConfigValidator.validateDisplayName(AbstractConfigValidator.java:124)
```

## After this PR
==COMMIT_MSG==
Fix publishing to gradle plugins portal.
==COMMIT_MSG==

... by adding `displayName` property. And ensure we set `description` too in case it becomes required.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

