### PR TITLE
Fix publishing attempt 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,12 +100,14 @@ gradlePlugin {
             implementationClass = 'com.palantir.gradle.versions.VersionsLockPlugin'
             displayName = 'Compact, constraint-friendly lockfiles for your dependencies'
             description = displayName
+            tags.set(['versions'])
         }
         versionsProps {
             id = 'com.palantir.versions-props'
             implementationClass = 'com.palantir.gradle.versions.VersionsPropsPlugin'
             displayName = 'Inject version constraints into every configuration in your projects'
             description = displayName
+            tags.set(['versions'])
         }
     }
 }
@@ -116,7 +118,7 @@ afterEvaluate {
 }
 
 tasks.publish.dependsOn tasks.publishPlugins
-publishPlugins.onlyIf { versionDetails().isCleanTag }
+publishPlugins.onlyIf { !System.env.CI || versionDetails().isCleanTag }
 project.ext.'gradle.publish.key' = System.env["GRADLE_KEY"]
 project.ext.'gradle.publish.secret' = System.env["GRADLE_SECRET"]
 

--- a/changelog/@unreleased/pr-1078.v2.yml
+++ b/changelog/@unreleased/pr-1078.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Second attempt at fixing publishing to the gradle plugin portal.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1078


### PR DESCRIPTION
## Before this PR
#1077 did [not work](https://app.circleci.com/pipelines/github/palantir/gradle-consistent-versions/3041/workflows/e8d43ce0-581b-40d5-a902-3fbfef23bb5b/jobs/13375). You need to set `tags` too:

```
Caused by: java.lang.IllegalArgumentException: Plugin 'versionsLock' has no 'tags' property set
```

## After this PR
Set tags.

I found out you can run

```
./gradlew publishPlugins --validate-only
```

to check. It still fails, but now with 

```
> Missing publishing keys. Please set gradle.publish.key/gradle.publish.secret system properties or GRADLE_PUBLISH_KEY/GRADLE_PUBLISH_SECRET env variables or login using the login task.
```

...which is hopefully good enough.

==COMMIT_MSG==
Second attempt at fixing publishing to the gradle plugin portal.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

