### PR TITLE
Include stacktraces in error for "Could not compute lock state from configuration"

### DIFF
--- a/changelog/@unreleased/pr-1100.v2.yml
+++ b/changelog/@unreleased/pr-1100.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Include stacktraces in error for "Could not compute lock state from
+    configuration"
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1100

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -759,12 +759,19 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 .map(a -> (UnresolvedDependencyResult) a)
                 .collect(Collectors.toList());
         if (!unresolved.isEmpty()) {
-            throw new GradleException(String.format(
-                    "Could not compute lock state from configuration '%s' due to unresolved dependencies:\n%s",
+            GradleException gradleException = new GradleException(String.format(
+                    "Could not compute lock state from configuration '%s' due to unresolved dependencies "
+                            + "(see suppressed exceptions below for full stacktraces):\n%s",
                     UNIFIED_CLASSPATH_CONFIGURATION_NAME,
                     unresolved.stream()
                             .map(this::formatUnresolvedDependencyResult)
                             .collect(Collectors.joining("\n"))));
+
+            unresolved.forEach(unresolvedDependencyResult -> {
+                gradleException.addSuppressed(unresolvedDependencyResult.getFailure());
+            });
+
+            throw gradleException;
         }
     }
 


### PR DESCRIPTION
## Before this PR
When you get the "Could not compute lock state from configuration", it summarises the errors but does not show you a stracktrace:

```
 * project : (requested: 'project :' because: requested)
      Failures:
         - Could not resolve project :.
         - Not allowed to resolve configuration ':shadeTransitively' at configuration time (https://guides.gradle.org/performance/#don_t_resolve_dependencies_at_configuration_time). Please upgrade your plugins and double-check your gradle scripts (see stacktrace)
	at com.palantir.gradle.versions.VersionsLockPlugin.failIfAnyDependenciesUnresolved(VersionsLockPlugin.java:754)
	at com.palantir.gradle.versions.VersionsLockPlugin.lambda$apply$11(VersionsLockPlugin.java:291)
	at com.google.common.base.Suppliers$MemoizingSupplier.get(Suppliers.java:136)
```

this makes it very hard to work out where the error is coming from.

## After this PR
==COMMIT_MSG==
Include stacktraces in error for "Could not compute lock state from configuration"
==COMMIT_MSG==

We add all the sub-stacktraces as suppressed so you can actually see them:

```
Caused by: org.gradle.api.GradleException: Could not compute lock state from configuration 'unifiedClasspath' due to unresolved dependencies:
 * project : (requested: 'project :' because: requested)
      Failures:
         - Could not resolve project :.
         - Not allowed to resolve configuration ':shadeTransitively' at configuration time (https://guides.gradle.org/performance/#don_t_resolve_dependencies_at_configuration_time). Please upgrade your plugins and double-check your gradle scripts (see stacktrace)
	at com.palantir.gradle.versions.VersionsLockPlugin.failIfAnyDependenciesUnresolved(VersionsLockPlugin.java:762)
	at com.palantir.gradle.versions.VersionsLockPlugin.lambda$apply$11(VersionsLockPlugin.java:299)
	at com.google.common.base.Suppliers$MemoizingSupplier.get(Suppliers.java:136)
        //snip
	Suppressed: org.gradle.internal.resolve.ModuleVersionResolveException: Could not resolve project :.
	Caused by: org.gradle.api.GradleException: Not allowed to resolve configuration ':shadeTransitively' at configuration time (https://guides.gradle.org/performance/#don_t_resolve_dependencies_at_configuration_time). Please upgrade your plugins and double-check your gradle scripts (see stacktrace)
		at com.palantir.gradle.versions.VersionsPropsPlugin.lambda$setupConfiguration$13(VersionsPropsPlugin.java:223)
                 // snip
		at com.palantir.gradle.shadowjar.ShadowJarPlugin.lambda$setupShadowJarToShadeTheCorrectDependencies$13(ShadowJarPlugin.java:142)
		at com.google.common.base.Suppliers$MemoizingSupplier.get(Suppliers.java:136)
		at com.palantir.gradle.shadowjar.ShadowJarPlugin.lambda$setupShadowJarToShadeTheCorrectDependencies$14(ShadowJarPlugin.java:176)
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

