### PR TITLE
Lock JMH configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ com.jayway.awaitility:awaitility:1.6.5 (1 constraints: c615c1d2)
 ```
 
 The lockfile sources production dependencies from the _compileClasspath_ and _runtimeClasspath_ configurations, and
-test dependencies from the compile/runtime classpaths of any source set that ends in test (e.g. `test`, `integrationTest`,
-`eteTest`).
+test dependencies from the compile/runtime classpaths of any source set named `jmh` or whose name ends in "test"
+(e.g. `test`, `integrationTest`, `eteTest`).
 
 There is a `verifyLocks` task (automatically run as part of `check`) that will ensure `versions.lock` is still consistent
 with the current dependencies.

--- a/changelog/@unreleased/pr-1113.v2.yml
+++ b/changelog/@unreleased/pr-1113.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Include JMH configurations in the locked test configurations.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1113

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -999,8 +999,10 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
             // Use heuristic for test source sets.
             sourceSets
-                    .matching(sourceSet ->
-                            sourceSet.getName().toLowerCase(Locale.ROOT).endsWith("test"))
+                    .matching(sourceSet -> {
+                        String name = sourceSet.getName().toLowerCase(Locale.ROOT);
+                        return name.equals("jmh") || name.endsWith("test");
+                    })
                     .forEach(sourceSet -> lockedConfigurations.addAllTestConfigurations(
                             getConfigurationsForSourceSet(project, sourceSet)));
         }


### PR DESCRIPTION
We have a number of repos that use https://github.com/melix/jmh-gradle-plugin or a custom `jmh` source set to write JMH benchmarks. We want to also lock these configurations and have versions recommended by GCV.

Currently running `./gradlew compileJmhJava --write-locks` fails because of missing versions:

```
$ ./gradlew compileJmhJava --write-locks

> Configure project :
Finished writing lock state to /Volumes/git/example/versions.lock

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':example:compileJmhJava'.
> Could not resolve all task dependencies for configuration ':example:jmhCompileClasspath'.
   > Could not find com.palantir.config.crypto:encrypted-config-value-module:.
     Required by:
         project :example
```