### PR TITLE
Support dependency option in why task

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ There is a `verifyLocks` task (automatically run as part of `check`) that will e
 with the current dependencies.
 
 ### ./gradlew why
-To understand why a particular version in your lockfile has been chosen, run `./gradlew why --hash a60c3ce8` to expand the constraints:
+To understand why a particular version in your lockfile has been chosen, run `./gradlew why --dependency <dependency>` to expand the constraints:
 ```
 > Task :why
 com.fasterxml.jackson.core:jackson-databind:2.9.8
@@ -159,9 +159,6 @@ This is effectively just a more concise version of `dependencyInsight`:
 ```
 ./gradlew  dependencyInsight --configuration unifiedClasspath --dependency jackson-databind
 ```
-
-You can check multiple dependencies at once by passing multiple comma-delimited hash values, e.g.
-`./gradlew why --hash a60c3ce8,400d4d2a`.
 
 ## ./gradlew checkUnusedConstraints
 `checkUnusedConstraints` prevents unnecessary constraints from accruing in your `versions.props` file. Run

--- a/changelog/@unreleased/pr-1115.v2.yml
+++ b/changelog/@unreleased/pr-1115.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: The `why` task now supports a `--dependency` option that matches the
+    behavior of `dependencyInsight`.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1115

--- a/src/main/java/com/palantir/gradle/versions/WhyDependencyTask.java
+++ b/src/main/java/com/palantir/gradle/versions/WhyDependencyTask.java
@@ -17,20 +17,16 @@
 package com.palantir.gradle.versions;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import com.palantir.gradle.versions.internal.MyModuleVersionIdentifier;
 import com.palantir.gradle.versions.lockstate.Dependents;
 import com.palantir.gradle.versions.lockstate.FullLockState;
 import com.palantir.gradle.versions.lockstate.Line;
 import com.palantir.gradle.versions.lockstate.LockStates;
 import java.nio.file.Path;
-import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -42,11 +38,13 @@ import org.gradle.api.tasks.options.Option;
 public class WhyDependencyTask extends DefaultTask {
 
     private final Property<String> hashOption;
+    private final Property<String> dependencyOption;
     private final Property<FullLockState> fullLockState;
     private Path lockfile;
 
     public WhyDependencyTask() {
         this.hashOption = getProject().getObjects().property(String.class);
+        this.dependencyOption = getProject().getObjects().property(String.class);
         this.fullLockState = getProject().getObjects().property(FullLockState.class);
 
         setGroup("Help");
@@ -56,6 +54,11 @@ public class WhyDependencyTask extends DefaultTask {
     @Option(option = "hash", description = "Hash from versions.lock to explain")
     public final void setHashOption(String string) {
         hashOption.set(string);
+    }
+
+    @Option(option = "dependency", description = "Dependency from versions.lock to explain")
+    public final void setDependencyOption(String string) {
+        dependencyOption.set(string);
     }
 
     public final void lockfile(Path path) {
@@ -69,22 +72,22 @@ public class WhyDependencyTask extends DefaultTask {
     @TaskAction
     public final void taskAction() {
         // read the lockfile from disk so that we can fail fast without resolving anything if the hash isn't found
-        Multimap<String, Line> lineByHash = new ConflictSafeLockFile(lockfile)
-                .readLocks().allLines().stream()
-                        .collect(Multimaps.toMultimap(Line::dependentsHash, Function.identity(), HashMultimap::create));
+        List<Line> lines = new ConflictSafeLockFile(lockfile).readLocks().allLines();
 
-        if (!hashOption.isPresent()) {
-            Optional<String> example = lineByHash.keySet().stream()
-                    .map(h -> ", e.g. './gradlew why --hash " + h + "'")
-                    .findFirst();
+        if (!hashOption.isPresent() && !dependencyOption.isPresent()) {
+            Optional<String> example =
+                    lines.stream().findFirst().map(line -> ", e.g. './gradlew why --dependency " + line.name() + "'");
             throw new RuntimeException(
-                    "./gradlew why requires a '--hash <hash>' from versions.lock" + example.orElse(""));
+                    "./gradlew why requires a '--dependency <dependency>' option" + example.orElse(""));
         }
 
-        Set<String> hashes = new LinkedHashSet<>(Splitter.on(",").splitToList(hashOption.get()));
+        Optional<Set<String>> hashes = Optional.ofNullable(hashOption.getOrNull())
+                .map(hash -> Set.copyOf(Splitter.on(",").splitToList(hash)));
+        Optional<String> dependency = Optional.ofNullable(dependencyOption.getOrNull());
 
-        for (String hash : hashes) {
-            lineByHash.get(hash).forEach(line -> {
+        for (Line line : lines) {
+            if ((hashes.isPresent() && hashes.get().contains(line.dependentsHash()))
+                    || (dependency.isPresent() && line.identifier().toString().contains(dependency.get()))) {
                 ModuleVersionIdentifier key = MyModuleVersionIdentifier.of(line.group(), line.name(), line.version());
 
                 Optional<Dependents> entry = Stream.of(
@@ -101,7 +104,7 @@ public class WhyDependencyTask extends DefaultTask {
                     getLogger().lifecycle("\t{}", pretty);
                 });
                 getLogger().lifecycle("");
-            });
+            }
         }
     }
 }


### PR DESCRIPTION
## Before this PR

Using the `why` task to get information about multiple dependencies is rather cumbersome.

For example, I may want to get information about all Jackson dependencies. The only way to do that today is providing all the relevant hashes as a comma-separated value, which requires some command line manipulation:

```
rg jackson versions.lock | rg 'constraints: (\w+)' -or '$1' | tr '\n' ',' | xargs ./gradlew why --hash
``` 

## After this PR

The `dependencyInsight` command uses `--dependency` parameter which matches uses a simple `contains` check.

https://github.com/gradle/gradle/blob/5479bbb152f69f27746c4528778b5c01e6eb794a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/dsl/DependencyResultSpec.java#L34-L43

I find this easy to use and sufficient for nearly all the queries I want to make.

There's also value is offering an interface that is consistent with `dependencyInsight`.

This PR adds a `--dependency` option to the `why` task that behaves more-or-less identically to the same parameter with `dependencyInsight`.

For example, here's the output running against https://github.com/palantir/tritium:

```
tritium develop .$ ./gradlew --no-scan why --dependency safe-logging

> Task :why
com.palantir.safe-logging:logger:3.7.0
        projects -> 3.7.0
        com.palantir.nylon:nylon-threads -> 3.6.0
        com.palantir.tracing:tracing -> 3.5.0

com.palantir.safe-logging:logger-slf4j:3.7.0
        com.palantir.safe-logging:logger -> 3.7.0

com.palantir.safe-logging:logger-spi:3.7.0
        com.palantir.safe-logging:logger -> 3.7.0
        com.palantir.safe-logging:logger-slf4j -> 3.7.0

com.palantir.safe-logging:preconditions:3.7.0
        projects -> 3.7.0
        com.palantir.nylon:nylon-threads -> 3.6.0
        com.palantir.tracing:tracing -> 3.5.0

com.palantir.safe-logging:safe-logging:3.7.0
        projects -> 3.7.0
        com.palantir.nylon:nylon-threads -> 3.6.0
        com.palantir.safe-logging:logger -> 3.7.0
        com.palantir.safe-logging:logger-spi -> 3.7.0
        com.palantir.safe-logging:preconditions -> 3.7.0
        com.palantir.tracing:tracing -> 3.5.0
```

The `--hash` parameter is still supported to maintain backwards compatibility.

