### PR TITLE
Adds support for use with java-test-fixtures, a core Gradle plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ com.jayway.awaitility:awaitility:1.6.5 (1 constraints: c615c1d2)
 ```
 
 The lockfile sources production dependencies from the _compileClasspath_ and _runtimeClasspath_ configurations, and
-test dependencies from the compile/runtime classpaths of any source set named `jmh` or whose name ends in "test"
-(e.g. `test`, `integrationTest`, `eteTest`).
+test dependencies from the compile/runtime classpaths of any source set named `jmh` or whose name starts with or ends 
+in "test" (e.g. `test`, `integrationTest`, `eteTest`).
 
 There is a `verifyLocks` task (automatically run as part of `check`) that will ensure `versions.lock` is still consistent
 with the current dependencies.

--- a/changelog/@unreleased/pr-1118.v2.yml
+++ b/changelog/@unreleased/pr-1118.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Include test configurations starting with "test" in the locked test configurations. Supports Gradle test fixtures plugins.
+  links:
+    - https://github.com/palantir/gradle-consistent-versions/pull/1118

--- a/changelog/@unreleased/pr-1118.v2.yml
+++ b/changelog/@unreleased/pr-1118.v2.yml
@@ -1,5 +1,0 @@
-type: improvement
-improvement:
-  description: Include test configurations starting with "test" in the locked test configurations. Supports Gradle test fixtures plugins.
-  links:
-    - https://github.com/palantir/gradle-consistent-versions/pull/1118

--- a/changelog/@unreleased/pr-1118.v2.yml
+++ b/changelog/@unreleased/pr-1118.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Include test configurations starting with "test" in the locked test configurations. Supports
+    Gradle test fixtures plugins.
+  links:
+    - https://github.com/palantir/gradle-consistent-versions/pull/1118

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -1001,7 +1001,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
             sourceSets
                     .matching(sourceSet -> {
                         String name = sourceSet.getName().toLowerCase(Locale.ROOT);
-                        return name.equals("jmh") || name.endsWith("test");
+                        return name.equals("jmh") || name.endsWith("test") || name.startsWith("test");
                     })
                     .forEach(sourceSet -> lockedConfigurations.addAllTestConfigurations(
                             getConfigurationsForSourceSet(project, sourceSet)));

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -849,9 +849,8 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         buildFile << """
             apply plugin: 'java'
-            sourceSets {
-                testFixtures
-            }           
+            apply plugin: 'java-test-fixtures'
+                     
             dependencies {
                 implementation 'ch.qos.logback:logback-classic:1.2.3'
                 testImplementation 'junit:junit:4.10'


### PR DESCRIPTION
## Before this PR

Currently, there is no support for using  java-test-fixtures, a core Gradle plugin. When using a test fixture, this plugin will fail. As an example, here is an error message that will be logged:

`Couldn't determine scope for dependency: com.h2database:h2:2.2.224`

if the build.gradle file is as follows:
```groovy
dependencies {
    testFixturesApi 'com.h2database:h2'
}
```

### Related Issues
https://github.com/palantir/gradle-consistent-versions/issues/691
https://github.com/palantir/gradle-consistent-versions/issues/308

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds support for use with java-test-fixtures, a core Gradle plugin.
==COMMIT_MSG==

A case to check for test sourceSets starting with the word "test" has been added, as suggested in #691 by @carterkozak. I have also included a test case to check that the lock file is properly generated when using the testFixtures plugin.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

The logic is dead-simple, so it is unlikely to cause unforeseen bugs. However, this now means that the plugin may change some sourceSets from production to test. I imagine that this impact will be small because it is unlikely many people are labelling their production source sets with test as a prefix. If the impact is deemed too high, then I also would be happy just to scan for the prefix 'testFixture'

