### PR TITLE
More specific command in versions.lock header comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Direct dependencies are specified in a top level `versions.props` file and then 
     com.squareup.okhttp3:okhttp = 3.12.0
     ```
 
-4. Run **`./gradlew --write-locks`** and see your versions.lock file be automatically created. This file should be checked into your repo:
+4. Run **`./gradlew writeVersionsLock`** and see your versions.lock file be automatically created. This file should be checked into your repo:
 
     ```bash
-    # Run ./gradlew --write-locks to regenerate this file
+    # Run ./gradlew writeVersionsLock to regenerate this file
     com.squareup.okhttp3:okhttp:3.12.0 (1 constraints: 38053b3b)
     com.squareup.okio:okio:1.15.0 (1 constraints: 810cbb09)
     ```

--- a/changelog/@unreleased/pr-1122.v2.yml
+++ b/changelog/@unreleased/pr-1122.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: More specific command in versions.lock header comment
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1122

--- a/src/main/java/com/palantir/gradle/versions/ConflictSafeLockFile.java
+++ b/src/main/java/com/palantir/gradle/versions/ConflictSafeLockFile.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
 import org.gradle.api.GradleException;
 
 final class ConflictSafeLockFile {
-    private static final String HEADER_COMMENT = "# Run ./gradlew --write-locks to regenerate this file";
+    private static final String HEADER_COMMENT = "# Run ./gradlew writeVersionsLock to regenerate this file";
     private static final Pattern LINE_PATTERN =
             Pattern.compile("(?<group>[^(:]+):(?<artifact>[^(:]+):(?<version>[^(:\\s]+)"
                     + "\\s+\\((?<num>\\d+) constraints: (?<hash>\\w+)\\)");

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -218,7 +218,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         def expectedLock = """\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeVersionsLock to regenerate this file
             test-alignment:module-that-should-be-aligned-up:1.1 (1 constraints: a5041a2c)
             test-alignment:module-with-higher-version:1.1 (1 constraints: a6041b2c)
         """.stripIndent()
@@ -248,7 +248,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         def expectedLock = """\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeVersionsLock to regenerate this file
             org.slf4j:slf4j-api:1.7.25 (1 constraints: 4105483b)
         """.stripIndent()
         file('versions.lock').text == expectedLock
@@ -306,7 +306,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         runTasks('--write-locks')
 
         file('versions.lock').text == """\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeVersionsLock to regenerate this file
             org.slf4j:slf4j-api:1.7.25 (1 constraints: 4105483b)
             org1:platform:1.0 (1 constraints: a5041a2c)
             org2:platform:1.0 (1 constraints: a5041a2c)

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -627,7 +627,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         file('versions.lock').readLines() == [
-                '# Run ./gradlew --write-locks to regenerate this file',
+                '# Run ./gradlew writeVersionsLock to regenerate this file',
                 'org:platform:1.0 (1 constraints: a5041a2c)',
         ]
 
@@ -710,7 +710,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         then: 'slf4j-api still appears in the lock file'
         file('versions.lock').readLines() == [
-                '# Run ./gradlew --write-locks to regenerate this file',
+                '# Run ./gradlew writeVersionsLock to regenerate this file',
                 'ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)',
                 'org.slf4j:slf4j-api:1.7.25 (1 constraints: 400d4d2a)',
         ]
@@ -797,7 +797,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks('--write-locks')
         def expected = """\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeVersionsLock to regenerate this file
             ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)
             org.slf4j:slf4j-api:1.7.25 (2 constraints: 7917e690)
              
@@ -829,7 +829,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks('--write-locks')
         def expected = """\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeVersionsLock to regenerate this file
             ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)
             org.slf4j:slf4j-api:1.7.25 (2 constraints: 7917e690)
              
@@ -859,7 +859,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks('--write-locks')
         def expected = """\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeVersionsLock to regenerate this file
              
             [Test dependencies]
             junit:junit:4.10 (1 constraints: d904fd30)
@@ -889,7 +889,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks('--write-locks')
         def expected = """\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeVersionsLock to regenerate this file
              
             [Test dependencies]
             ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)
@@ -1121,7 +1121,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks("--write-locks")
         file('versions.lock').text == """\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeVersionsLock to regenerate this file
             ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)
             org.slf4j:slf4j-api:1.7.25 (2 constraints: 8012a437)
         """.stripIndent()
@@ -1141,7 +1141,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         def lockFileContent = """\
-            # Run ./gradlew --write-locks to regenerate this file
+            # Run ./gradlew writeVersionsLock to regenerate this file
         """.stripIndent()
 
         file('versions.lock').text = lockFileContent

--- a/src/test/resources/sample-versions.lock
+++ b/src/test/resources/sample-versions.lock
@@ -1,4 +1,4 @@
-# Run ./gradlew --write-locks to regenerate this file
+# Run ./gradlew writeVersionsLock to regenerate this file
 aopalliance:aopalliance:1.0 (1 constraints: 170a83ac)
 ch.qos.logback:logback-access:1.2.3 (3 constraints: 4f354f15)
 ch.qos.logback:logback-classic:1.2.3 (5 constraints: 9351d6aa)

--- a/versions.lock
+++ b/versions.lock
@@ -1,4 +1,4 @@
-# Run ./gradlew --write-locks to regenerate this file
+# Run ./gradlew writeVersionsLock to regenerate this file
 com.google.code.findbugs:jsr305:3.0.2 (2 constraints: 1d0fb186)
 com.google.errorprone:error_prone_annotations:2.11.0 (2 constraints: 7b0f13a1)
 com.google.guava:failureaccess:1.0.1 (1 constraints: 140ae1b4)


### PR DESCRIPTION
Builds on https://github.com/palantir/gradle-consistent-versions/pull/723 which added the `writeVersionsLock` command

## Before this PR
Users (like me) will run `./gradlew --write-locks` to update the `versions.lock` file for merge conflicts (as directed by the header comment) and end up doing much more work than needed.  On one internal repo I have, it's a 30s vs 5m30s difference!

## After this PR
==COMMIT_MSG==
More specific command in versions.lock header comment
==COMMIT_MSG==

The old `--write-locks` syntax still works, it is just not advertised in the file's header comment.

## Possible downsides?
The `--write-locks` syntax is now de-emphasized, and users wanting to update all their lock files in one command may have trouble discovering it.