### PR TITLE
Support test fixtures

### DIFF
--- a/changelog/@unreleased/pr-1171.v2.yml
+++ b/changelog/@unreleased/pr-1171.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Support test fixtures.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1171

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -48,7 +48,6 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -1000,8 +999,11 @@ public class VersionsLockPlugin implements Plugin<Project> {
             // Use heuristic for test source sets.
             sourceSets
                     .matching(sourceSet -> {
-                        String name = sourceSet.getName().toLowerCase(Locale.ROOT);
-                        return name.equals("jmh") || name.endsWith("test");
+                        String name = sourceSet.getName();
+                        return name.equals("test")
+                                || name.equals("testFixtures")
+                                || name.equals("jmh")
+                                || name.endsWith("Test");
                     })
                     .forEach(sourceSet -> lockedConfigurations.addAllTestConfigurations(
                             getConfigurationsForSourceSet(project, sourceSet)));


### PR DESCRIPTION
When using [Gradle test fixtures](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures), if the `testFixtures` source set uses a dependency that is not a direct dependencies of other source sets, then you get an error when computing dependency locks.

```
$ ./gradlew writeVersionsLocks

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'my-project-root'.
> Couldn't determine scope for dependency: com.example.foo:foo:1.2.3
```