### PR TITLE
Consistently use writeVersionsLocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Direct dependencies are specified in a top level `versions.props` file and then 
     com.squareup.okhttp3:okhttp = 3.12.0
     ```
 
-4. Run **`./gradlew writeVersionsLock`** and see your versions.lock file be automatically created. This file should be checked into your repo:
+4. Run **`./gradlew writeVersionsLocks`** and see your versions.lock file be automatically created. This file should be checked into your repo:
 
     ```bash
-    # Run ./gradlew writeVersionsLock to regenerate this file
+    # Run ./gradlew writeVersionsLocks to regenerate this file
     com.squareup.okhttp3:okhttp:3.12.0 (1 constraints: 38053b3b)
     com.squareup.okio:okio:1.15.0 (1 constraints: 810cbb09)
     ```

--- a/src/main/java/com/palantir/gradle/versions/ConflictSafeLockFile.java
+++ b/src/main/java/com/palantir/gradle/versions/ConflictSafeLockFile.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 import org.gradle.api.GradleException;
 
 final class ConflictSafeLockFile {
-    private static final String HEADER_COMMENT = "# Run ./gradlew writeVersionsLock to regenerate this file";
+    private static final String HEADER_COMMENT = "# Run ./gradlew writeVersionsLocks to regenerate this file";
     private static final Pattern LINE_PATTERN =
             Pattern.compile("(?<group>[^(:]+):(?<artifact>[^(:]+):(?<version>[^(:\\s]+)"
                     + "\\s+\\((?<num>\\d+) constraints: (?<hash>\\w+)\\)");

--- a/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
+++ b/src/main/java/com/palantir/gradle/versions/VerifyLocksTask.java
@@ -39,7 +39,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
 public class VerifyLocksTask extends DefaultTask {
 
-    private static final String WRITE_LOCKS_SUGGESTION = "./gradlew writeVersionsLock";
+    private static final String WRITE_LOCKS_SUGGESTION = "./gradlew writeVersionsLocks";
     private final File outputFile;
     private final Property<LockState> persistedLockState;
     private final Property<LockState> currentLockState;

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -259,8 +259,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
         // write the versions lock task without running --write-locks code from any other gradle plugin. Unfortunately,
         // we can't just have the task run the write locks code as we need to write the locks in afterEvaluate.
         project.getTasks()
-                .register(WRITE_VERSIONS_LOCKS_TASK, WriteVersionsLocksMarkerTask.class, writeVersionsLock -> {
-                    writeVersionsLock.getOutputs().upToDateWhen(_ignored -> false);
+                .register(WRITE_VERSIONS_LOCKS_TASK, WriteVersionsLocksMarkerTask.class, writeVersionsLocks -> {
+                    writeVersionsLocks.getOutputs().upToDateWhen(_ignored -> false);
                 });
 
         // afterEvaluate is necessary to ensure all projects' dependencies have been configured, because we

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -85,12 +85,12 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def '#gradleVersionNumber: can write locks using writeVersionsLock'() {
+    def '#gradleVersionNumber: can write locks using writeVersionsLocks'() {
         setup:
         gradleVersion = gradleVersionNumber
 
         when:
-        runTasks('writeVersionsLock')
+        runTasks('writeVersionsLocks')
 
         then:
         new File(projectDir, "versions.lock").exists()
@@ -100,7 +100,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GRADLE_VERSIONS
     }
 
-    def '#gradleVersionNumber: can write locks using abbreviated writeVersionsLock'() {
+    def '#gradleVersionNumber: can write locks using abbreviated writeVersionsLocks'() {
         setup:
         gradleVersion = gradleVersionNumber
 
@@ -218,7 +218,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         def expectedLock = """\
-            # Run ./gradlew writeVersionsLock to regenerate this file
+            # Run ./gradlew writeVersionsLocks to regenerate this file
             test-alignment:module-that-should-be-aligned-up:1.1 (1 constraints: a5041a2c)
             test-alignment:module-with-higher-version:1.1 (1 constraints: a6041b2c)
         """.stripIndent()
@@ -248,7 +248,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         def expectedLock = """\
-            # Run ./gradlew writeVersionsLock to regenerate this file
+            # Run ./gradlew writeVersionsLocks to regenerate this file
             org.slf4j:slf4j-api:1.7.25 (1 constraints: 4105483b)
         """.stripIndent()
         file('versions.lock').text == expectedLock
@@ -306,7 +306,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         runTasks('--write-locks')
 
         file('versions.lock').text == """\
-            # Run ./gradlew writeVersionsLock to regenerate this file
+            # Run ./gradlew writeVersionsLocks to regenerate this file
             org.slf4j:slf4j-api:1.7.25 (1 constraints: 4105483b)
             org1:platform:1.0 (1 constraints: a5041a2c)
             org2:platform:1.0 (1 constraints: a5041a2c)

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsLockPluginIntegrationSpec.groovy
@@ -627,7 +627,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         file('versions.lock').readLines() == [
-                '# Run ./gradlew writeVersionsLock to regenerate this file',
+                '# Run ./gradlew writeVersionsLocks to regenerate this file',
                 'org:platform:1.0 (1 constraints: a5041a2c)',
         ]
 
@@ -710,7 +710,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
 
         then: 'slf4j-api still appears in the lock file'
         file('versions.lock').readLines() == [
-                '# Run ./gradlew writeVersionsLock to regenerate this file',
+                '# Run ./gradlew writeVersionsLocks to regenerate this file',
                 'ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)',
                 'org.slf4j:slf4j-api:1.7.25 (1 constraints: 400d4d2a)',
         ]
@@ -797,7 +797,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks('--write-locks')
         def expected = """\
-            # Run ./gradlew writeVersionsLock to regenerate this file
+            # Run ./gradlew writeVersionsLocks to regenerate this file
             ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)
             org.slf4j:slf4j-api:1.7.25 (2 constraints: 7917e690)
              
@@ -829,7 +829,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks('--write-locks')
         def expected = """\
-            # Run ./gradlew writeVersionsLock to regenerate this file
+            # Run ./gradlew writeVersionsLocks to regenerate this file
             ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)
             org.slf4j:slf4j-api:1.7.25 (2 constraints: 7917e690)
              
@@ -859,7 +859,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks('--write-locks')
         def expected = """\
-            # Run ./gradlew writeVersionsLock to regenerate this file
+            # Run ./gradlew writeVersionsLocks to regenerate this file
              
             [Test dependencies]
             junit:junit:4.10 (1 constraints: d904fd30)
@@ -889,7 +889,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks('--write-locks')
         def expected = """\
-            # Run ./gradlew writeVersionsLock to regenerate this file
+            # Run ./gradlew writeVersionsLocks to regenerate this file
              
             [Test dependencies]
             ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)
@@ -1121,7 +1121,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         expect:
         runTasks("--write-locks")
         file('versions.lock').text == """\
-            # Run ./gradlew writeVersionsLock to regenerate this file
+            # Run ./gradlew writeVersionsLocks to regenerate this file
             ch.qos.logback:logback-classic:1.2.3 (1 constraints: 0805f935)
             org.slf4j:slf4j-api:1.7.25 (2 constraints: 8012a437)
         """.stripIndent()
@@ -1141,7 +1141,7 @@ class VersionsLockPluginIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         def lockFileContent = """\
-            # Run ./gradlew writeVersionsLock to regenerate this file
+            # Run ./gradlew writeVersionsLocks to regenerate this file
         """.stripIndent()
 
         file('versions.lock').text = lockFileContent

--- a/src/test/resources/sample-versions.lock
+++ b/src/test/resources/sample-versions.lock
@@ -1,4 +1,4 @@
-# Run ./gradlew writeVersionsLock to regenerate this file
+# Run ./gradlew writeVersionsLocks to regenerate this file
 aopalliance:aopalliance:1.0 (1 constraints: 170a83ac)
 ch.qos.logback:logback-access:1.2.3 (3 constraints: 4f354f15)
 ch.qos.logback:logback-classic:1.2.3 (5 constraints: 9351d6aa)


### PR DESCRIPTION
The `writeVersionsLocks` task accepts slightly mismatched names. Internally and in our error messages we should consistently use the canonical name - `writeVersionsLocks`. This convention is consistent with our other lock tasks in external and internal plugins (namely, the task name ends with "Locks" plural).