### PR TITLE
use findByType when not sure if java plugin exists

### DIFF
--- a/changelog/@unreleased/pr-1231.v2.yml
+++ b/changelog/@unreleased/pr-1231.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: use findByType when not sure if java plugin exists
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1231

--- a/src/main/java/com/palantir/gradle/versions/GradleConfigurations.java
+++ b/src/main/java/com/palantir/gradle/versions/GradleConfigurations.java
@@ -54,7 +54,7 @@ final class GradleConfigurations {
      * applied, this returns an empty set.
      */
     private static Set<String> getLegacyJavaConfigurations(Project project) {
-        JavaPluginExtension javaConvention = project.getExtensions().getByType(JavaPluginExtension.class);
+        JavaPluginExtension javaConvention = project.getExtensions().findByType(JavaPluginExtension.class);
         if (javaConvention == null) {
             return ImmutableSet.of();
         }


### PR DESCRIPTION
## Before this PR
The migration from Convention.findPlugin to Extensions should have been .findByType to avoid exceptions when it's not found.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
use findByType when not sure if java plugin exists #1231
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

