### PR TITLE
Add WstxInputFactory and WstxOutputFactory to XmlMapper

### DIFF
--- a/changelog/@unreleased/pr-1245.v2.yml
+++ b/changelog/@unreleased/pr-1245.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Add WstxInputFactory and WstxOutputFactory to XmlMapper
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1245

--- a/src/main/java/com/palantir/gradle/versions/GenerateMavenRepositoriesTask.java
+++ b/src/main/java/com/palantir/gradle/versions/GenerateMavenRepositoriesTask.java
@@ -16,6 +16,8 @@
 
 package com.palantir.gradle.versions;
 
+import com.ctc.wstx.stax.WstxInputFactory;
+import com.ctc.wstx.stax.WstxOutputFactory;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -38,7 +40,8 @@ import org.immutables.value.Value;
 
 public abstract class GenerateMavenRepositoriesTask extends DefaultTask {
 
-    private static final ObjectMapper XML_MAPPER = new XmlMapper().registerModule(new GuavaModule());
+    private static final ObjectMapper XML_MAPPER =
+            new XmlMapper(new WstxInputFactory(), new WstxOutputFactory()).registerModule(new GuavaModule());
 
     private static final String MAVEN_REPOSITORIES_FILE_NAME = ".idea/gcv-maven-repositories.xml";
 


### PR DESCRIPTION
## Before this PR
We were not specifying which Input/Output factories to use for our XMLMapper.
If not specified, the default mapper is initialised using the class loader [here](https://github.com/FasterXML/jackson-dataformat-xml/blob/jackson-dataformat-xml-2.15.2/src/main/java/com/fasterxml/jackson/dataformat/xml/XmlFactory.java#L122-L133).

When not specified, we might be picking a Stax XMLStreamWriter from another library which can then cause failure 

## After this PR
==COMMIT_MSG==
Add WstxInputFactory and WstxOutputFactory to XmlMapper
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

