### PR TITLE
Add `checkOverbroadConstraints` to `check` task

### DIFF
--- a/changelog/@unreleased/pr-1258.v2.yml
+++ b/changelog/@unreleased/pr-1258.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Add `checkOverbroadConstraints` to `check` task
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1258

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -92,16 +92,14 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                     });
             project.getTasks().named("check").configure(task -> task.dependsOn(checkNoUnusedConstraints));
 
-            // Currently checkOverbroadConstraints is not running as part of check while for testing - uncomment once
-            // testing is complete (also uncomment groovy test)
-            //            TaskProvider<CheckOverbroadConstraints> checkOverbroadConstraints =
-            project.getTasks().register("checkOverbroadConstraints", CheckOverbroadConstraints.class, task -> {
-                task.getLockFile().set(project.getLayout().getProjectDirectory().file("versions.lock"));
-                task.getPropsFile()
-                        .set(project.getLayout().getProjectDirectory().file("versions.props"));
-            });
-            //                project.getTasks().named("check").configure(task ->
-            // task.dependsOn(checkOverbroadConstraints));
+            TaskProvider<CheckOverbroadConstraints> checkOverbroadConstraints = project.getTasks()
+                    .register("checkOverbroadConstraints", CheckOverbroadConstraints.class, task -> {
+                        task.getLockFile()
+                                .set(project.getLayout().getProjectDirectory().file("versions.lock"));
+                        task.getPropsFile()
+                                .set(project.getLayout().getProjectDirectory().file("versions.props"));
+                    });
+            project.getTasks().named("check").configure(task -> task.dependsOn(checkOverbroadConstraints));
 
             // Create "platform" configuration in root project, which will hold the versions props constraints
             project.getConfigurations().register(GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME, conf -> {

--- a/src/test/groovy/com/palantir/gradle/versions/CheckOverbroadConstraintsIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/CheckOverbroadConstraintsIntegrationSpec.groovy
@@ -53,12 +53,11 @@ class CheckOverbroadConstraintsIntegrationSpec extends IntegrationSpec {
         runTasks('checkOverbroadConstraints')
     }
 
-//    Currently checkOverbroadConstraints is not running as part of check while for testing uncomment once re-added to check
-//    def 'Task should run as part of :check'() {
-//        expect:
-//        def result = runTasks('check', '-m')
-//        result.output.contains(':checkOverbroadConstraints')
-//    }
+    def 'Task should run as part of :check'() {
+        expect:
+        def result = runTasks('check', '-m')
+        result.output.contains(':checkOverbroadConstraints')
+    }
 
     def 'All versions are pinned'() {
         when:


### PR DESCRIPTION
## Before this PR
Previously while testing `checkOverbroadConstraints`  was not ran as part of `check` so was not in use

## After this PR
Now we require `checkOverbroadConstraints` as part of `check` so it will be ran on every PR
==COMMIT_MSG==
Add `checkOverbroadConstraints` to `check` task
==COMMIT_MSG==

## Possible downsides?
If this is merged before an excavator capable of running fix is released it will break upgrades to new versions of `gradle-consistent-versions`

