### PR TITLE
Fix `ConfigureIdeaPluginXml` by removing use of internal `ImmutableMap` class

### DIFF
--- a/changelog/@unreleased/pr-1274.v2.yml
+++ b/changelog/@unreleased/pr-1274.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix `ConfigureIdeaPluginXml` by removing use of internal `ImmutableMap`
+    class
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1274

--- a/gradle-consistent-versions-idea/src/main/groovy/com/palantir/gradle/versions/ConfigureIdeaPluginXml.groovy
+++ b/gradle-consistent-versions-idea/src/main/groovy/com/palantir/gradle/versions/ConfigureIdeaPluginXml.groovy
@@ -18,7 +18,6 @@ package com.palantir.gradle.versions
 
 import groovy.xml.XmlNodePrinter
 import groovy.xml.XmlParser
-import org.gradle.internal.impldep.com.google.common.collect.ImmutableMap
 import org.xml.sax.SAXException
 
 import javax.xml.parsers.ParserConfigurationException
@@ -38,7 +37,7 @@ class ConfigureIdeaPluginXml {
             if (!createIfAbsent) {
                 return;
             }
-            rootNode = new Node(null, "project", ImmutableMap.of("version", "4"));
+            rootNode = new Node(null, "project", [version: "4"]);
         }
 
         configureExternalDependencies(rootNode, minVersion)


### PR DESCRIPTION
## Before this PR
Sometimes the `ConfigureIdeaPluginXml. updateIdeaXmlFile` method would fail with `Caused by: java.lang.NoClassDefFoundError: org/gradle/internal/impldep/com/google/common/collect/ImmutableMap` 

This was due to the use of the `ImmutableMap` class which comes from `org.gradle.internal.impldep.com.google.common.collect`  this is internal and not always available at runtime


## After this PR
`ImmutableMap` has been replaced with a standard Groovy map literal which will always be available at runtime
==COMMIT_MSG==
Fix `ConfigureIdeaPluginXml` by removing use of internal `ImmutableMap` class
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

