### PR TITLE
Groovy based interop API

### DIFF
--- a/gradle-consistent-versions-groovy-api/build.gradle
+++ b/gradle-consistent-versions-groovy-api/build.gradle
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'groovy'
+apply plugin: 'com.palantir.external-publish-jar'
+
+dependencies {
+    compileOnly gradleApi()
+
+    testImplementation rootProject
+    testImplementation 'com.netflix.nebula:nebula-test'
+}

--- a/gradle-consistent-versions-groovy-api/src/main/groovy/com/palantir/gradle/versions/VersionRecommendationsInterop.groovy
+++ b/gradle-consistent-versions-groovy-api/src/main/groovy/com/palantir/gradle/versions/VersionRecommendationsInterop.groovy
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions
+
+import org.gradle.api.Project
+
+/**
+ * This is groovy so we can use it's automatic reflection abilities to call the correct methods. This avoids having
+ * a direct dependency on GCV, which is sometimes using in `plugins {` blocks so is in a different classloader, making
+ * configuring using Java correctly without ClassCastExceptions exceedingly difficult.
+ * All these methods will only exclude if GCV is applied
+ */
+public final class VersionRecommendationsInterop {
+
+    public static void excludeConfigurations(Project project, String... configurationNames) {
+        Project rootProject = project.rootProject
+        rootProject.pluginManager.withPlugin('com.palantir.versions-props') {
+            def versionRecommendationsExtension = rootProject.extensions.getByName('versionRecommendations')
+            versionRecommendationsExtension.excludeConfigurations(configurationNames)
+        }
+    }
+
+    private VersionRecommendationsInterop() {}
+}

--- a/gradle-consistent-versions-groovy-api/src/main/groovy/com/palantir/gradle/versions/VersionsLockInterop.groovy
+++ b/gradle-consistent-versions-groovy-api/src/main/groovy/com/palantir/gradle/versions/VersionsLockInterop.groovy
@@ -1,0 +1,63 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions
+
+import org.gradle.api.Project
+
+/**
+ * This is groovy so we can use it's automatic reflection abilities to call the correct methods. This avoids having
+ * a direct dependency on GCV, which is sometimes using in `plugins {` blocks so is in a different classloader, making
+ * configuring using Java correctly without ClassCastExceptions exceedingly difficult.
+ * All these methods will only exclude if GCV is applied
+ */
+public final class VersionsLockInterop {
+    enum Scope {
+        PRODUCTION,
+        TEST
+    }
+
+    public static void lockConfiguration(Project project, Scope scope, String configurationName) {
+        withVersionsLockExtension(project) { versionsLockExtension ->
+            def closure = {
+                from configurationName
+            }
+            switch (scope) {
+                case Scope.PRODUCTION:
+                    versionsLockExtension.production(closure)
+                    break
+                case Scope.TEST:
+                    versionsLockExtension.test(closure)
+                    break
+            }
+        }
+    }
+
+    public static void disableJavaPluginDefaults(Project project) {
+        withVersionsLockExtension(project) { versionsLockExtension ->
+            versionsLockExtension.disableJavaPluginDefaults()
+        }
+    }
+
+    private static void withVersionsLockExtension(Project project, Closure closure) {
+        project.pluginManager.withPlugin('com.palantir.versions-lock') {
+            def versionsLockExtension = project.extensions.getByName('versionsLock')
+            closure.call(versionsLockExtension)
+        }
+    }
+
+    private VersionsLockInterop() {}
+}

--- a/gradle-consistent-versions-groovy-api/src/test/groovy/com/palantir/gradle/versions/VersionRecommendationsInteropSpec.groovy
+++ b/gradle-consistent-versions-groovy-api/src/test/groovy/com/palantir/gradle/versions/VersionRecommendationsInteropSpec.groovy
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions
+
+
+import nebula.test.ProjectSpec
+
+class VersionRecommendationsInteropSpec extends ProjectSpec {
+    def setup() {
+        project.apply plugin: 'com.palantir.consistent-versions'
+    }
+
+    def 'can exclude a configuration'() {
+        when:
+        VersionRecommendationsInterop.excludeConfigurations(project, 'blah')
+
+        then:
+        def extension = project.rootProject.extensions.getByType(VersionRecommendationsExtension)
+        extension.shouldExcludeConfiguration('blah')
+    }
+}

--- a/gradle-consistent-versions-groovy-api/src/test/groovy/com/palantir/gradle/versions/VersionsLockInteropSpec.groovy
+++ b/gradle-consistent-versions-groovy-api/src/test/groovy/com/palantir/gradle/versions/VersionsLockInteropSpec.groovy
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions
+
+
+import nebula.test.ProjectSpec
+
+class VersionsLockInteropSpec extends ProjectSpec {
+    def setup() {
+        project.apply plugin: 'com.palantir.consistent-versions'
+    }
+
+    def 'can lock a production configuration'() {
+        when:
+        VersionsLockInterop.lockConfiguration(project, VersionsLockInterop.Scope.PRODUCTION, 'blah')
+
+        then:
+        def extension = project.extensions.getByType(VersionsLockExtension)
+        extension.productionConfigurations.contains('blah')
+    }
+
+    def 'can lock a test configuration'() {
+        when:
+        VersionsLockInterop.lockConfiguration(project, VersionsLockInterop.Scope.TEST, 'blah')
+
+        then:
+        def extension = project.extensions.getByType(VersionsLockExtension)
+        extension.testConfigurations.contains('blah')
+    }
+
+    def 'can disable java plugins defaults'() {
+        when:
+        VersionsLockInterop.disableJavaPluginDefaults(project)
+
+        then:
+        def extension = project.extensions.getByType(VersionsLockExtension)
+        !extension.isUseJavaPluginDefaults()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,4 +10,5 @@ buildscript {
 apply plugin: 'com.palantir.jdks.settings'
 rootProject.name = 'gradle-consistent-versions'
 
+include 'gradle-consistent-versions-groovy-api'
 include 'gradle-consistent-versions-idea'


### PR DESCRIPTION
## Before this PR
In a variety of internal and external projects, we use "groovy interop" classes to change stuff on the GCV extension without actually loading GCV classes.

This is because GCV (for some reason) is the only real project which we decided to excavate out to use the `plugins` block. When a plugin listed in the buildscript tries to access an extension from from a plugin in the plugins block, the classes for the extension are in different classloaders. This means that you get `ClassCastException` (??? need to recheck)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

