### PR TITLE
copy configuration set first before filtering

### DIFF
--- a/changelog/@unreleased/pr-1307.v2.yml
+++ b/changelog/@unreleased/pr-1307.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: copy configuration set first before filtering
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1307

--- a/src/main/java/com/palantir/gradle/versions/GradleConfigurations.java
+++ b/src/main/java/com/palantir/gradle/versions/GradleConfigurations.java
@@ -43,8 +43,7 @@ final class GradleConfigurations {
      */
     public static Set<Configuration> getResolvableConfigurations(Project project) {
         Set<String> legacyJavaConfigurations = getLegacyJavaConfigurations(project);
-        Set<Configuration> allConfigs = project.getConfigurations().stream().collect(ImmutableSet.toImmutableSet());
-        return allConfigs.stream()
+        return ImmutableSet.copyOf(project.getConfigurations()).stream()
                 .filter(Configuration::isCanBeResolved)
                 .filter(conf -> !legacyJavaConfigurations.contains(conf.getName()))
                 .filter(conf -> DEPRECATED_SOURCESET_SUFFIXES.stream()

--- a/src/main/java/com/palantir/gradle/versions/GradleConfigurations.java
+++ b/src/main/java/com/palantir/gradle/versions/GradleConfigurations.java
@@ -38,10 +38,13 @@ final class GradleConfigurations {
      *
      * Note that we need to do a defensive copy here to guard against concurrent modification.
      * See https://github.com/palantir/gradle-consistent-versions/pull/812
+     * And even more defensive:
+     * https://github.com/palantir/gradle-consistent-versions/pull/1307
      */
     public static Set<Configuration> getResolvableConfigurations(Project project) {
         Set<String> legacyJavaConfigurations = getLegacyJavaConfigurations(project);
-        return project.getConfigurations().stream()
+        Set<Configuration> allConfigs = project.getConfigurations().stream().collect(ImmutableSet.toImmutableSet());
+        return allConfigs.stream()
                 .filter(Configuration::isCanBeResolved)
                 .filter(conf -> !legacyJavaConfigurations.contains(conf.getName()))
                 .filter(conf -> DEPRECATED_SOURCESET_SUFFIXES.stream()


### PR DESCRIPTION
## Before this PR
One project was getting ConcurrentModificationException when running check (which ran checkUnusedConstraints).  Stack:
`Caused by: java.util.ConcurrentModificationException
        at org.gradle.api.internal.DefaultDomainObjectCollection$IteratorImpl.next(DefaultDomainObjectCollection.java:467)
        at com.palantir.gradle.versions.GradleConfigurations.getResolvableConfigurations(GradleConfigurations.java:49)
        at com.palantir.gradle.versions.CheckUnusedConstraintsTask.getResolvedModuleIdentifiers(CheckUnusedConstraintsTask.java:167)
        at com.palantir.gradle.versions.VersionsPropsPlugin.lambda$apply$1(VersionsPropsPlugin.java:85)
        at com.palantir.gradle.versions.VersionsPropsPlugin.lambda$apply$2(VersionsPropsPlugin.java:88)
        at org.gradle.api.internal.provider.DefaultProvider.calculateOwnValue(DefaultProvider.java:72)
        at org.gradle.api.internal.provider.AbstractMinimalProvider.calculateValue(AbstractMinimalProvider.java:115)
        at org.gradle.api.internal.provider.Collectors$ElementsFromCollectionProvider.collectEntries(Collectors.java:276)
        at org.gradle.api.internal.provider.AbstractCollectionProperty$CollectingSupplier.calculateValue(AbstractCollectionProperty.java:494)
        at org.gradle.api.internal.provider.AbstractCollectionProperty.finalValue(AbstractCollectionProperty.java:306)
        at org.gradle.api.internal.provider.AbstractCollectionProperty.finalValue(AbstractCollectionProperty.java:79)
        at org.gradle.api.internal.provider.AbstractProperty.finalizeNow(AbstractProperty.java:281)
        ... 109 more
`

Cannot see any reason why this could be an issue.  Note that others tried to harden the method against this issue several yeas ago in #812.  Maybe there is still a window in certain circumstances. 

## After this PR
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

