### PR TITLE
synchronise `excludeConfigurations` to make it thread safe

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionRecommendationsExtension.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionRecommendationsExtension.java
@@ -37,6 +37,8 @@ public class VersionRecommendationsExtension {
 
     private final SetProperty<String> excludeConfigurations;
 
+    private final Object lock = new Object();
+
     @Inject
     public VersionRecommendationsExtension(Project project) {
         excludeConfigurations = project.getObjects().setProperty(String.class).empty();
@@ -44,11 +46,15 @@ public class VersionRecommendationsExtension {
     }
 
     public final void excludeConfigurations(String... configurations) {
-        excludeConfigurations.addAll(configurations);
+        synchronized (lock) {
+            excludeConfigurations.addAll(configurations);
+        }
     }
 
     public final void setExcludeConfigurations(String... configurations) {
-        excludeConfigurations.set(Lists.newArrayList(configurations));
+        synchronized (lock) {
+            excludeConfigurations.set(Lists.newArrayList(configurations));
+        }
     }
 
     final Provider<Set<String>> getExcludeConfigurations() {


### PR DESCRIPTION
## Before this PR
Previously we where using `SetProperty<String>` without `synchronized` which is not thread safe see the [docs](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/SetProperty.html)
 
## After this PR
Now we use `synchronized` with a lock to ensure that changes to `excludeConfigurations` are atomic

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
synchronise `excludeConfigurations` to make it thread safe
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

