### PR TITLE
Remove Stray Usage of `getProject()`

### DIFF
--- a/changelog/@unreleased/pr-1324.v2.yml
+++ b/changelog/@unreleased/pr-1324.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Avoid `getProject()` in `checkUnusedConstraints` that prevents intra
+    project task parallelism.
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1324

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
@@ -124,8 +124,7 @@ public class CheckUnusedConstraintsTask extends DefaultTask {
         if (unusedConstraints.isEmpty()) {
             return;
         } else if (shouldFix.get()) {
-            getProject()
-                    .getLogger()
+            getLogger()
                     .lifecycle("Removing unused pins from versions.props:\n"
                             + unusedConstraints.stream()
                                     .map(name -> String.format(" - '%s'", name))


### PR DESCRIPTION
Use the task level logger to avoid global lock contention