### PR TITLE
Ensure `--write-locks` works when used in included builds

### DIFF
--- a/.baseline/checkstyle/custom-suppressions.xml
+++ b/.baseline/checkstyle/custom-suppressions.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--
+  ~ (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<!-- IMPORTANT ECLIPSE NOTE: If you change this file, you must restart Eclipse
+ for your changes to take effect in its Checkstyle integration. -->
+
+<!-- custom-suppressions.xml allows users to specify suppressions that will not be overridden by
+     baselineUpdateConfig -->
+<suppressions>
+
+    <!-- To support versions of Gradle < 8.3, we need to reach into `GradleInternal` which is an internal Gradle type   -->
+    <suppress files="[/\\]src[/\\].*ConsistentVersionsPlugin.java" checks="IllegalImport" />
+
+</suppressions>

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Direct dependencies are specified in a top level `versions.props` file and then 
 1. [Motivation](#motivation)
     1. An evolution of `nebula.dependency-recommender`
 1. [Concepts](#concepts)
-    1. versions.props: lower bounds for dependencies
-    1. versions.lock: compact representation of your prod classpath
-    1. ./gradlew why
-    1. ./gradlew checkUnusedConstraints
-    1. ./gradlew checkOverbroadConstraints
-    1. getVersion
+    1. `versions.props`: lower bounds for dependencies
+    1. `versions.lock`: compact representation of your prod classpath
+    1. `./gradlew why`
+    1. `./gradlew checkUnusedConstraints`
+    1. `./gradlew checkOverbroadConstraints`
+    1. `getVersion`
     1. BOMs
     1. Specifying exact versions
     1. Downgrading things
@@ -98,7 +98,7 @@ Unfortunately, failOnVersionConflict means developers often pick conflict resolu
 
 ## Concepts
 
-### versions.props: lower bounds for dependencies
+### `versions.props`: lower bounds for dependencies
 Specify versions for your direct dependencies in a single root-level `versions.props` file. Think of these versions as the _minimum_ versions your project requires.
 
 ```
@@ -119,7 +119,7 @@ This has the side effect that a line referring specifically to a jar is independ
 [virtual platform]: https://docs.gradle.org/current/userguide/dependency_version_alignment.html
 
 
-### versions.lock: compact representation of your prod classpath
+### `versions.lock`: compact representation of your prod classpath
 When you run `./gradlew --write-locks`, the plugin will automatically write a new file: `versions.lock` which contains a version for every single one of your transitive dependencies.
 
 Notably, this lockfile is a _compact_ representation of your dependency graph as it just has one line per dependency (unlike nebula lock files which spanned thousands of lines).
@@ -144,7 +144,7 @@ test dependencies from the compile/runtime classpaths of any source set named `j
 There is a `verifyLocks` task (automatically run as part of `check`) that will ensure `versions.lock` is still consistent
 with the current dependencies.
 
-### ./gradlew why
+### `./gradlew why`
 To understand why a particular version in your lockfile has been chosen, run `./gradlew why --dependency <dependency>` to expand the constraints:
 ```
 > Task :why
@@ -161,11 +161,11 @@ This is effectively just a more concise version of `dependencyInsight`:
 ./gradlew  dependencyInsight --configuration unifiedClasspath --dependency jackson-databind
 ```
 
-### ./gradlew checkUnusedConstraints
+### `./gradlew checkUnusedConstraints`
 `checkUnusedConstraints` prevents unnecessary constraints from accruing in your `versions.props` file. Run
 `./gradlew checkUnusedConstraints --fix` to automatically remove any unused constraints from your props file.
 
-### ./gradlew checkOverbroadConstraints
+### `./gradlew checkOverbroadConstraints`
 `checkOverbroadConstraints` prevents over-broad constants/`versions.props` pins. Run `./gradlew checkOverbroadConstraints --fix` 
 to automatically add the necessary constrains to your props file.
 
@@ -196,7 +196,7 @@ org.junit.jupiter:* = 5.10.2
 org.junit.platform:* = 1.10.2
 ```
 
-### getVersion
+### `getVersion`
 If you want to use the resolved version of some dependency elsewhere in your Gradle files, gradle-consistent-versions offers the `getVersion(group, name, [configuration])` convenience function. For example:
 
 ```gradle
@@ -373,6 +373,21 @@ To exclude a configuration from receiving the constraints, you can add it to `ex
     versionRecommendations {
         excludeConfigurations 'zinc'
     }
+
+### Included Builds
+You can use `gradle-consistent-versions` in an included build as well as the root build. They are entirely independent, that is:
+* GCV constraints in the inner build have **no** effect on the parent build unless there is a dependency from the parent build on a project of the inner build, but even then it stems from what dependencies the project dependency has.
+* GCV constraints in a parent build have **no** effect on the inner build.
+
+#### How does it work?
+
+A lot of the internal configurations and dependencies used within `gradle-consistent-versions` are done with Gradle variants. These are selected via Gradle attributes and/or capabilities. In addition to fencing off internal configurations and dependencies for usage in `gradle-consistent-versions` only, we encode a unique identifier for each build in the build tree e.g. select variants that are for GCV and are in the root build.
+
+> [!CAUTION]
+> As plugin versions for builds are independent, ensure both builds are at *least* `2.37.0`. Earlier versions of `gradle-consistent-versions` do not have the attributes required to separate different build roots from each other. This is especially relevant where the parent build is on `2.36.0` and below regardless of the version of `gradle-consistent-versions` in the included build.   
+
+#### Gradle Support
+Included builds have gotten better support as Gradle versions have been released. Your mileage may vary on Gradle 7 and may not produce the right constraints/lock files in parent builds.
 
 ## Migration
 Using a combination of automation and some elbow grease, we've migrated ~150 projects from `nebula.dependency-recommender` to `com.palantir.consistent-version`:

--- a/changelog/@unreleased/pr-1393.v2.yml
+++ b/changelog/@unreleased/pr-1393.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Ensure `--write-locks` works when used in included builds
+  links:
+  - https://github.com/palantir/gradle-consistent-versions/pull/1393

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -42,8 +42,8 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
         if (!project.getRootProject().equals(project)) {
             throw new GradleException("Must be applied only to root project");
         }
-        project.allprojects(p -> {
-            AttributesSchema attributesSchema = p.getDependencies().getAttributesSchema();
+        project.allprojects(proj -> {
+            AttributesSchema attributesSchema = proj.getDependencies().getAttributesSchema();
             attributesSchema.attribute(GcvBuildPath.ATTRIBUTE);
         });
         project.getPluginManager().apply(VersionsLockPlugin.class);

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -19,8 +19,11 @@ package com.palantir.gradle.versions;
 import com.palantir.gradle.ideaconfiguration.IdeaConfigurationExtension;
 import com.palantir.gradle.ideaconfiguration.IdeaConfigurationPlugin;
 import org.gradle.api.GradleException;
+import org.gradle.api.Named;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributesSchema;
 
 public class ConsistentVersionsPlugin implements Plugin<Project> {
     static final String CONSISTENT_VERSIONS_USAGE = "consistent-versions-usage";
@@ -30,6 +33,10 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
         if (!project.getRootProject().equals(project)) {
             throw new GradleException("Must be applied only to root project");
         }
+        project.allprojects(p -> {
+            AttributesSchema attributesSchema = p.getDependencies().getAttributesSchema();
+            attributesSchema.attribute(GcvBuildPath.ATTRIBUTE);
+        });
         project.getPluginManager().apply(VersionsLockPlugin.class);
         project.getPluginManager().apply(VersionsPropsPlugin.class);
         project.getPluginManager().apply(GetVersionPlugin.class);
@@ -44,5 +51,10 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
                 proj.getPluginManager().apply(FixLegacyJavaConfigurationsPlugin.class);
             });
         });
+    }
+
+    public interface GcvBuildPath extends Named {
+        Attribute<GcvBuildPath> ATTRIBUTE =
+                Attribute.of("com.palantir.consistent-versions.build-path", GcvBuildPath.class);
     }
 }

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -24,13 +24,16 @@ import org.gradle.api.Named;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.util.GradleVersion;
 
+@SuppressWarnings("IllegalImport")
 public class ConsistentVersionsPlugin implements Plugin<Project> {
     static final String CONSISTENT_VERSIONS_USAGE = "consistent-versions-usage";
 
@@ -72,11 +75,11 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
          *
          * <ul>
          *   <li>they don't cause an ambiguity between the copied and the original {@code apiElements},
-         *       {@code runtimeElements} etc., when a resolution with a required usage is performed (such as by resolving a
-         *       {@code compileClasspath} or {@code runtimeClasspath} configuration)
-         *   <li>to avoid the configurations we create to calculate locks being resolved as an actual candidate in normal
-         *       resolution, when all other candidates didn't match, simply because it had completely distinct attributes
-         *       from the requested attributes.
+         *       {@code runtimeElements} etc., when a resolution with a required usage is performed (such as by
+         *       resolving a {@code compileClasspath} or {@code runtimeClasspath} configuration)
+         *   <li>to avoid the configurations we create to calculate locks being resolved as an actual candidate in
+         *       normal resolution, when all other candidates didn't match, simply because it had completely distinct
+         *       attributes from the requested attributes.
          * </ul>
          */
         public final Usage gradleUsageForGcv() {
@@ -100,11 +103,16 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
                 return ((GradleInternal) getGradle()).getIdentityPath().getPath();
             }
         }
+
+        public final void configureGcvBaseAttributes(HasAttributes hasAttributes) {
+            AttributeContainer attributes = hasAttributes.getAttributes();
+            attributes.attribute(Usage.USAGE_ATTRIBUTE, gradleUsageForGcv());
+            attributes.attribute(GcvBuildPath.ATTRIBUTE, buildPath());
+        }
     }
 
     public abstract static class GcvBuildPath implements Named {
         public static final Attribute<GcvBuildPath> ATTRIBUTE =
                 Attribute.of("com.palantir.consistent-versions.build-path", GcvBuildPath.class);
     }
-
 }

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.versions;
 
 import com.palantir.gradle.ideaconfiguration.IdeaConfigurationExtension;
 import com.palantir.gradle.ideaconfiguration.IdeaConfigurationPlugin;
+import java.util.Objects;
 import javax.inject.Inject;
 import org.gradle.api.GradleException;
 import org.gradle.api.Named;
@@ -79,6 +80,27 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
                 return ((GradleInternal) getGradle()).getIdentityPath().getPath();
             }
         }
+
+        @Override
+        public final String toString() {
+            return getName();
+        }
+
+        @Override
+        public final boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof GcvBuildPath other)) {
+                return false;
+            }
+            return Objects.equals(getName(), other.getName());
+        }
+
+        @Override
+        public final int hashCode() {
+            return Objects.hashCode(getName());
+        }
     }
 
     /**
@@ -100,6 +122,11 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
         @Override
         public final String getName() {
             return CONSISTENT_VERSIONS_USAGE;
+        }
+
+        @Override
+        public String toString() {
+            return getName();
         }
     }
 }

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -18,12 +18,17 @@ package com.palantir.gradle.versions;
 
 import com.palantir.gradle.ideaconfiguration.IdeaConfigurationExtension;
 import com.palantir.gradle.ideaconfiguration.IdeaConfigurationPlugin;
+import javax.inject.Inject;
 import org.gradle.api.GradleException;
 import org.gradle.api.Named;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.util.GradleVersion;
 
 public class ConsistentVersionsPlugin implements Plugin<Project> {
     static final String CONSISTENT_VERSIONS_USAGE = "consistent-versions-usage";
@@ -53,8 +58,48 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
         });
     }
 
-    public interface GcvBuildPath extends Named {
-        Attribute<GcvBuildPath> ATTRIBUTE =
+    /**
+     * Whilst calculating the {@code unifiedClasspath} for a parent build, we don't want internal configurations from
+     * <em>child</em> builds - i.e. included builds - to be selected. We effectively want to consume the "published"
+     * variant i.e. if the included build were to be an external library we were to consume, what dependencies and jars
+     * do we get?
+     */
+    public abstract static class GcvBuildPath implements Named {
+        public static final Attribute<GcvBuildPath> ATTRIBUTE =
                 Attribute.of("com.palantir.consistent-versions.build-path", GcvBuildPath.class);
+
+        @Inject
+        protected abstract Gradle getGradle();
+
+        @Override
+        public final String getName() {
+            if (GradleVersion.current().compareTo(GradleVersion.version("8.3")) >= 0) {
+                return getGradle().getRootProject().getBuildTreePath();
+            } else {
+                return ((GradleInternal) getGradle()).getIdentityPath().getPath();
+            }
+        }
+    }
+
+    /**
+     * We don't want the consumable configurations we create to have any known usage, so we give them this usage.
+     * This is so that:
+     *
+     * <ul>
+     *   <li>they don't cause an ambiguity between the copied and the original {@code apiElements},
+     *       {@code runtimeElements} etc., when a resolution with a required usage is performed (such as by resolving a
+     *       {@code compileClasspath} or {@code runtimeClasspath} configuration)
+     *   <li>to avoid the configurations we create to calculate locks being resolved as an actual candidate in normal
+     *       resolution, when all other candidates didn't match, simply because it had completely distinct attributes
+     *       from the requested attributes.
+     * </ul>
+     */
+    public enum GcvAsGradleUsage implements Usage {
+        INSTANCE;
+
+        @Override
+        public final String getName() {
+            return CONSISTENT_VERSIONS_USAGE;
+        }
     }
 }

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -18,7 +18,6 @@ package com.palantir.gradle.versions;
 
 import com.palantir.gradle.ideaconfiguration.IdeaConfigurationExtension;
 import com.palantir.gradle.ideaconfiguration.IdeaConfigurationPlugin;
-import java.util.Objects;
 import javax.inject.Inject;
 import org.gradle.api.GradleException;
 import org.gradle.api.Named;
@@ -29,6 +28,7 @@ import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.invocation.Gradle;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.util.GradleVersion;
 
 public class ConsistentVersionsPlugin implements Plugin<Project> {
@@ -59,74 +59,52 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
         });
     }
 
-    /**
-     * Whilst calculating the {@code unifiedClasspath} for a parent build, we don't want internal configurations from
-     * <em>child</em> builds - i.e. included builds - to be selected. We effectively want to consume the "published"
-     * variant i.e. if the included build were to be an external library we were to consume, what dependencies and jars
-     * do we get?
-     */
-    public abstract static class GcvBuildPath implements Named {
-        public static final Attribute<GcvBuildPath> ATTRIBUTE =
-                Attribute.of("com.palantir.consistent-versions.build-path", GcvBuildPath.class);
-
+    public abstract static class GcvAttributes {
         @Inject
         protected abstract Gradle getGradle();
 
-        @Override
-        public final String getName() {
+        @Inject
+        protected abstract ObjectFactory getObjects();
+
+        /**
+         * We don't want the consumable configurations we create to have any known usage, so we give them this usage.
+         * This is so that:
+         *
+         * <ul>
+         *   <li>they don't cause an ambiguity between the copied and the original {@code apiElements},
+         *       {@code runtimeElements} etc., when a resolution with a required usage is performed (such as by resolving a
+         *       {@code compileClasspath} or {@code runtimeClasspath} configuration)
+         *   <li>to avoid the configurations we create to calculate locks being resolved as an actual candidate in normal
+         *       resolution, when all other candidates didn't match, simply because it had completely distinct attributes
+         *       from the requested attributes.
+         * </ul>
+         */
+        public final Usage gradleUsageForGcv() {
+            return getObjects().named(Usage.class, CONSISTENT_VERSIONS_USAGE);
+        }
+
+        /**
+         * Whilst calculating the {@code unifiedClasspath} for a parent build, we don't want internal configurations
+         * from <em>child</em> builds - i.e. included builds - to be selected. We effectively want to consume the
+         * "published" variant i.e. if the included build were to be an external library we were to consume, what
+         * dependencies and jars do we get?
+         */
+        public final GcvBuildPath buildPath() {
+            return getObjects().named(GcvBuildPath.class, buildPathName());
+        }
+
+        private String buildPathName() {
             if (GradleVersion.current().compareTo(GradleVersion.version("8.3")) >= 0) {
                 return getGradle().getRootProject().getBuildTreePath();
             } else {
                 return ((GradleInternal) getGradle()).getIdentityPath().getPath();
             }
         }
-
-        @Override
-        public final String toString() {
-            return getName();
-        }
-
-        @Override
-        public final boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (!(obj instanceof GcvBuildPath other)) {
-                return false;
-            }
-            return Objects.equals(getName(), other.getName());
-        }
-
-        @Override
-        public final int hashCode() {
-            return Objects.hashCode(getName());
-        }
     }
 
-    /**
-     * We don't want the consumable configurations we create to have any known usage, so we give them this usage.
-     * This is so that:
-     *
-     * <ul>
-     *   <li>they don't cause an ambiguity between the copied and the original {@code apiElements},
-     *       {@code runtimeElements} etc., when a resolution with a required usage is performed (such as by resolving a
-     *       {@code compileClasspath} or {@code runtimeClasspath} configuration)
-     *   <li>to avoid the configurations we create to calculate locks being resolved as an actual candidate in normal
-     *       resolution, when all other candidates didn't match, simply because it had completely distinct attributes
-     *       from the requested attributes.
-     * </ul>
-     */
-    public enum GcvAsGradleUsage implements Usage {
-        INSTANCE;
-
-        @Override
-        public final String getName() {
-            return CONSISTENT_VERSIONS_USAGE;
-        }
-
-        @Override
-        public String toString() {
-            return getName();
-        }
+    public abstract static class GcvBuildPath implements Named {
+        public static final Attribute<GcvBuildPath> ATTRIBUTE =
+                Attribute.of("com.palantir.consistent-versions.build-path", GcvBuildPath.class);
     }
+
 }

--- a/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/ConsistentVersionsPlugin.java
@@ -26,7 +26,6 @@ import org.gradle.api.Project;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributesSchema;
-import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.invocation.Gradle;
@@ -104,8 +103,7 @@ public class ConsistentVersionsPlugin implements Plugin<Project> {
             }
         }
 
-        public final void configureGcvBaseAttributes(HasAttributes hasAttributes) {
-            AttributeContainer attributes = hasAttributes.getAttributes();
+        public final void configureGcvBaseAttributes(AttributeContainer attributes) {
             attributes.attribute(Usage.USAGE_ATTRIBUTE, gradleUsageForGcv());
             attributes.attribute(GcvBuildPath.ATTRIBUTE, buildPath());
         }

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
+import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvAsGradleUsage;
 import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvBuildPath;
 import com.palantir.gradle.versions.internal.MyModuleIdentifier;
 import com.palantir.gradle.versions.internal.MyModuleVersionIdentifier;
@@ -92,7 +93,6 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.logging.configuration.ShowStacktrace;
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Property;
@@ -100,6 +100,7 @@ import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.ivy.IvyPublication;
 import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
@@ -107,7 +108,7 @@ import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.util.GradleVersion;
 import org.immutables.value.Value;
 
-public class VersionsLockPlugin implements Plugin<Project> {
+public abstract class VersionsLockPlugin implements Plugin<Project> {
     private static final Logger log = Logging.getLogger(VersionsLockPlugin.class);
     static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("7.6.4");
 
@@ -174,29 +175,12 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
     private final ShowStacktrace showStacktrace;
 
-    /**
-     * We don't want the consumable configurations we create ({@link #PLACEHOLDER_CONFIGURATION_NAME},
-     * {@link #CONSISTENT_VERSIONS_PRODUCTION}, {@link #CONSISTENT_VERSIONS_TEST}) and downstream collected
-     * {@link #recursivelyCopyProjectDependencies(Project, DependencySet) configurations that we copy} to have any known
-     * usage, so we give them this usage. This is so that:
-     *
-     * <ul>
-     *   <li>they don't cause an ambiguity between the copied and the original {@code apiElements},
-     *       {@code runtimeElements} etc., when a resolution with a required usage is performed (such as by resolving a
-     *       {@code compileClasspath} or {@code runtimeClasspath} configuration)
-     *   <li>to avoid {@link #PLACEHOLDER_CONFIGURATION_NAME} being resolved as an actual candidate in normal
-     *       resolution, when all other candidates didn't match, simply because it had completely distinct attributes
-     *       from the requested attributes.
-     * </ul>
-     */
-    private final Usage internalUsage;
-
-    private GcvBuildPath gcvBuildPath;
+    @Nested
+    public abstract GcvBuildPath getGcvBuildPath();
 
     @Inject
-    public VersionsLockPlugin(Gradle gradle, ObjectFactory objectFactory) {
+    public VersionsLockPlugin(Gradle gradle) {
         showStacktrace = gradle.getStartParameter().getShowStacktrace();
-        internalUsage = objectFactory.named(Usage.class, ConsistentVersionsPlugin.CONSISTENT_VERSIONS_USAGE);
     }
 
     static Path getRootLockFile(Project project) {
@@ -218,9 +202,6 @@ public class VersionsLockPlugin implements Plugin<Project> {
             });
         });
 
-        gcvBuildPath = project.getObjects()
-                .named(GcvBuildPath.class, project.getRootProject().getBuildTreePath());
-
         @SuppressWarnings("for-rollout:ConfigurationAvoidanceRegistration")
         Configuration unifiedClasspath = project.getConfigurations()
                 .create(UNIFIED_CLASSPATH_CONFIGURATION_NAME, conf -> {
@@ -228,7 +209,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
                     // Attributes declared here will become required attributes when resolving this configuration
                     conf.getAttributes().attribute(GCV_USAGE_ATTRIBUTE, GcvUsage.GCV_SOURCE);
-                    conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
+                    conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
                 });
 
         project.allprojects(subproject -> {
@@ -247,8 +228,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
         // Create "platform" configuration in root project, which will hold the strictConstraints
         NamedDomainObjectProvider<Configuration> gcvLocksConfiguration = project.getConfigurations()
                 .register("gcvLocks", conf -> {
-                    conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
-                    conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
+                    conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
+                    conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
                     conf.getOutgoing().capability(GCV_LOCKS_CAPABILITY);
                     conf.setCanBeResolved(false);
                     conf.setVisible(false);
@@ -259,8 +240,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
         locksDependency.capabilities(moduleDependencyCapabilitiesHandler ->
                 moduleDependencyCapabilitiesHandler.requireCapabilities(GCV_LOCKS_CAPABILITY));
         locksDependency.attributes(attrs -> {
-            attrs.attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
-            attrs.attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
+            attrs.attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
+            attrs.attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
         });
 
         // This is a "marker" task that does nothing, it exists solely that we can detect if it has been run and so
@@ -418,8 +399,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false).setCanBeResolved(false);
 
             // Make sure it can never be selected as part of normal resolution that declares a required usage.
-            conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
-            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
+            conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
+            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
 
             // Mark it as a GCV_SOURCE, so that when we resolve {@link #UNIFIED_CLASSPATH_CONFIGURATION_NAME}
             // it becomes selected (as the best matching configuration) for the user's normal inter-project dependencies
@@ -433,8 +414,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false); // needn't be visible from other projects
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);
-            conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
-            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
+            conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
+            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
             conf.getOutgoing().capability(capabilityFor(project, GcvScope.PRODUCTION));
         });
 
@@ -443,17 +424,17 @@ public class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false); // needn't be visible from other projects
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);
-            conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
-            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
+            conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
+            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
             conf.getOutgoing().capability(capabilityFor(project, GcvScope.TEST));
         });
 
         unifiedClasspath
                 .getDependencies()
-                .add(createDependencyOnProjectWithScope(project, GcvScope.PRODUCTION, gcvBuildPath));
+                .add(createDependencyOnProjectWithScope(project, GcvScope.PRODUCTION, getGcvBuildPath()));
         unifiedClasspath
                 .getDependencies()
-                .add(createDependencyOnProjectWithScope(project, GcvScope.TEST, gcvBuildPath));
+                .add(createDependencyOnProjectWithScope(project, GcvScope.TEST, getGcvBuildPath()));
     }
 
     private static Map<String, String> capabilityFor(Project project, GcvScope scope) {
@@ -676,8 +657,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
                         ImmutableList.copyOf(copiedConf.getAllDependencyConstraints()));
             }
 
-            copiedConf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
-            copiedConf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
+            copiedConf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
+            copiedConf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
             // Must set this because we depend on this configuration when resolving unifiedClasspath.
             copiedConf.setCanBeConsumed(true);
             // Since we only depend on these from the same project (via CONSISTENT_VERSIONS_PRODUCTION or

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
+import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvBuildPath;
 import com.palantir.gradle.versions.internal.MyModuleIdentifier;
 import com.palantir.gradle.versions.internal.MyModuleVersionIdentifier;
 import com.palantir.gradle.versions.lockstate.Dependents;
@@ -190,6 +191,8 @@ public class VersionsLockPlugin implements Plugin<Project> {
      */
     private final Usage internalUsage;
 
+    private GcvBuildPath gcvBuildPath;
+
     @Inject
     public VersionsLockPlugin(Gradle gradle, ObjectFactory objectFactory) {
         showStacktrace = gradle.getStartParameter().getShowStacktrace();
@@ -215,6 +218,9 @@ public class VersionsLockPlugin implements Plugin<Project> {
             });
         });
 
+        gcvBuildPath = project.getObjects()
+                .named(GcvBuildPath.class, project.getRootProject().getBuildTreePath());
+
         @SuppressWarnings("for-rollout:ConfigurationAvoidanceRegistration")
         Configuration unifiedClasspath = project.getConfigurations()
                 .create(UNIFIED_CLASSPATH_CONFIGURATION_NAME, conf -> {
@@ -222,6 +228,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
                     // Attributes declared here will become required attributes when resolving this configuration
                     conf.getAttributes().attribute(GCV_USAGE_ATTRIBUTE, GcvUsage.GCV_SOURCE);
+                    conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
                 });
 
         project.allprojects(subproject -> {
@@ -241,6 +248,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
         NamedDomainObjectProvider<Configuration> gcvLocksConfiguration = project.getConfigurations()
                 .register("gcvLocks", conf -> {
                     conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
+                    conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
                     conf.getOutgoing().capability(GCV_LOCKS_CAPABILITY);
                     conf.setCanBeResolved(false);
                     conf.setVisible(false);
@@ -252,6 +260,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
                 moduleDependencyCapabilitiesHandler.requireCapabilities(GCV_LOCKS_CAPABILITY));
         locksDependency.attributes(attrs -> {
             attrs.attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
+            attrs.attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
         });
 
         // This is a "marker" task that does nothing, it exists solely that we can detect if it has been run and so
@@ -410,6 +419,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
 
             // Make sure it can never be selected as part of normal resolution that declares a required usage.
             conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
+            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
 
             // Mark it as a GCV_SOURCE, so that when we resolve {@link #UNIFIED_CLASSPATH_CONFIGURATION_NAME}
             // it becomes selected (as the best matching configuration) for the user's normal inter-project dependencies
@@ -424,6 +434,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);
             conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
+            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
             conf.getOutgoing().capability(capabilityFor(project, GcvScope.PRODUCTION));
         });
 
@@ -433,11 +444,16 @@ public class VersionsLockPlugin implements Plugin<Project> {
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);
             conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
+            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
             conf.getOutgoing().capability(capabilityFor(project, GcvScope.TEST));
         });
 
-        unifiedClasspath.getDependencies().add(createDependencyOnProjectWithScope(project, GcvScope.PRODUCTION));
-        unifiedClasspath.getDependencies().add(createDependencyOnProjectWithScope(project, GcvScope.TEST));
+        unifiedClasspath
+                .getDependencies()
+                .add(createDependencyOnProjectWithScope(project, GcvScope.PRODUCTION, gcvBuildPath));
+        unifiedClasspath
+                .getDependencies()
+                .add(createDependencyOnProjectWithScope(project, GcvScope.TEST, gcvBuildPath));
     }
 
     private static Map<String, String> capabilityFor(Project project, GcvScope scope) {
@@ -464,12 +480,14 @@ public class VersionsLockPlugin implements Plugin<Project> {
     }
 
     /** Create a dependency requiring capabilities for the listed scope. */
-    private static Dependency createDependencyOnProjectWithScope(Project project, GcvScope scope) {
+    private static Dependency createDependencyOnProjectWithScope(
+            Project project, GcvScope scope, GcvBuildPath gcvBuildPath) {
         ProjectDependency projectDependency =
                 (ProjectDependency) project.getDependencies().create(project);
         projectDependency.capabilities(moduleDependencyCapabilitiesHandler ->
                 moduleDependencyCapabilitiesHandler.requireCapabilities(capabilityFor(project, scope)));
-        projectDependency.attributes(attr -> attr.attribute(GCV_SCOPE_ATTRIBUTE, scope));
+        projectDependency.attributes(
+                attr -> attr.attribute(GCV_SCOPE_ATTRIBUTE, scope).attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath));
         return projectDependency;
     }
 
@@ -659,6 +677,7 @@ public class VersionsLockPlugin implements Plugin<Project> {
             }
 
             copiedConf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, internalUsage);
+            copiedConf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
             // Must set this because we depend on this configuration when resolving unifiedClasspath.
             copiedConf.setCanBeConsumed(true);
             // Since we only depend on these from the same project (via CONSISTENT_VERSIONS_PRODUCTION or

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -30,7 +30,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
-import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvAsGradleUsage;
+import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvAttributes;
 import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvBuildPath;
 import com.palantir.gradle.versions.internal.MyModuleIdentifier;
 import com.palantir.gradle.versions.internal.MyModuleVersionIdentifier;
@@ -176,7 +176,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
     private final ShowStacktrace showStacktrace;
 
     @Nested
-    public abstract GcvBuildPath getGcvBuildPath();
+    public abstract GcvAttributes getGcvAttributes();
 
     @Inject
     public VersionsLockPlugin(Gradle gradle) {
@@ -209,7 +209,9 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
 
                     // Attributes declared here will become required attributes when resolving this configuration
                     conf.getAttributes().attribute(GCV_USAGE_ATTRIBUTE, GcvUsage.GCV_SOURCE);
-                    conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
+                    conf.getAttributes()
+                            .attribute(
+                                    GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
                 });
 
         project.allprojects(subproject -> {
@@ -228,8 +230,11 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
         // Create "platform" configuration in root project, which will hold the strictConstraints
         NamedDomainObjectProvider<Configuration> gcvLocksConfiguration = project.getConfigurations()
                 .register("gcvLocks", conf -> {
-                    conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
-                    conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
+                    conf.getAttributes()
+                            .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
+                    conf.getAttributes()
+                            .attribute(
+                                    GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
                     conf.getOutgoing().capability(GCV_LOCKS_CAPABILITY);
                     conf.setCanBeResolved(false);
                     conf.setVisible(false);
@@ -240,8 +245,8 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
         locksDependency.capabilities(moduleDependencyCapabilitiesHandler ->
                 moduleDependencyCapabilitiesHandler.requireCapabilities(GCV_LOCKS_CAPABILITY));
         locksDependency.attributes(attrs -> {
-            attrs.attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
-            attrs.attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
+            attrs.attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
+            attrs.attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
         });
 
         // This is a "marker" task that does nothing, it exists solely that we can detect if it has been run and so
@@ -399,8 +404,10 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false).setCanBeResolved(false);
 
             // Make sure it can never be selected as part of normal resolution that declares a required usage.
-            conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
-            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
+            conf.getAttributes()
+                    .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
+            conf.getAttributes()
+                    .attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
 
             // Mark it as a GCV_SOURCE, so that when we resolve {@link #UNIFIED_CLASSPATH_CONFIGURATION_NAME}
             // it becomes selected (as the best matching configuration) for the user's normal inter-project dependencies
@@ -414,8 +421,10 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false); // needn't be visible from other projects
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);
-            conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
-            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
+            conf.getAttributes()
+                    .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
+            conf.getAttributes()
+                    .attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
             conf.getOutgoing().capability(capabilityFor(project, GcvScope.PRODUCTION));
         });
 
@@ -424,17 +433,21 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false); // needn't be visible from other projects
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);
-            conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
-            conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
+            conf.getAttributes()
+                    .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
+            conf.getAttributes()
+                    .attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
             conf.getOutgoing().capability(capabilityFor(project, GcvScope.TEST));
         });
 
         unifiedClasspath
                 .getDependencies()
-                .add(createDependencyOnProjectWithScope(project, GcvScope.PRODUCTION, getGcvBuildPath()));
+                .add(createDependencyOnProjectWithScope(
+                        project, GcvScope.PRODUCTION, getGcvAttributes().buildPath()));
         unifiedClasspath
                 .getDependencies()
-                .add(createDependencyOnProjectWithScope(project, GcvScope.TEST, getGcvBuildPath()));
+                .add(createDependencyOnProjectWithScope(
+                        project, GcvScope.TEST, getGcvAttributes().buildPath()));
     }
 
     private static Map<String, String> capabilityFor(Project project, GcvScope scope) {
@@ -657,8 +670,12 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
                         ImmutableList.copyOf(copiedConf.getAllDependencyConstraints()));
             }
 
-            copiedConf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GcvAsGradleUsage.INSTANCE);
-            copiedConf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
+            copiedConf
+                    .getAttributes()
+                    .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
+            copiedConf
+                    .getAttributes()
+                    .attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
             // Must set this because we depend on this configuration when resolving unifiedClasspath.
             copiedConf.setCanBeConsumed(true);
             // Since we only depend on these from the same project (via CONSISTENT_VERSIONS_PRODUCTION or

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -230,11 +230,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
         // Create "platform" configuration in root project, which will hold the strictConstraints
         NamedDomainObjectProvider<Configuration> gcvLocksConfiguration = project.getConfigurations()
                 .register("gcvLocks", conf -> {
-                    conf.getAttributes()
-                            .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
-                    conf.getAttributes()
-                            .attribute(
-                                    GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
+                    getGcvAttributes().configureGcvBaseAttributes(conf);
                     conf.getOutgoing().capability(GCV_LOCKS_CAPABILITY);
                     conf.setCanBeResolved(false);
                     conf.setVisible(false);
@@ -244,10 +240,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
                 (ProjectDependency) project.getDependencies().create(project);
         locksDependency.capabilities(moduleDependencyCapabilitiesHandler ->
                 moduleDependencyCapabilitiesHandler.requireCapabilities(GCV_LOCKS_CAPABILITY));
-        locksDependency.attributes(attrs -> {
-            attrs.attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
-            attrs.attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
-        });
+        getGcvAttributes().configureGcvBaseAttributes(locksDependency);
 
         // This is a "marker" task that does nothing, it exists solely that we can detect if it has been run and so
         // write the versions lock task without running --write-locks code from any other gradle plugin. Unfortunately,
@@ -404,10 +397,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false).setCanBeResolved(false);
 
             // Make sure it can never be selected as part of normal resolution that declares a required usage.
-            conf.getAttributes()
-                    .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
-            conf.getAttributes()
-                    .attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
+            getGcvAttributes().configureGcvBaseAttributes(conf);
 
             // Mark it as a GCV_SOURCE, so that when we resolve {@link #UNIFIED_CLASSPATH_CONFIGURATION_NAME}
             // it becomes selected (as the best matching configuration) for the user's normal inter-project dependencies
@@ -421,10 +411,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false); // needn't be visible from other projects
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);
-            conf.getAttributes()
-                    .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
-            conf.getAttributes()
-                    .attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
+            getGcvAttributes().configureGcvBaseAttributes(conf);
             conf.getOutgoing().capability(capabilityFor(project, GcvScope.PRODUCTION));
         });
 
@@ -433,10 +420,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false); // needn't be visible from other projects
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);
-            conf.getAttributes()
-                    .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
-            conf.getAttributes()
-                    .attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
+            getGcvAttributes().configureGcvBaseAttributes(conf);
             conf.getOutgoing().capability(capabilityFor(project, GcvScope.TEST));
         });
 
@@ -670,12 +654,8 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
                         ImmutableList.copyOf(copiedConf.getAllDependencyConstraints()));
             }
 
-            copiedConf
-                    .getAttributes()
-                    .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
-            copiedConf
-                    .getAttributes()
-                    .attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
+            getGcvAttributes().configureGcvBaseAttributes(copiedConf);
+
             // Must set this because we depend on this configuration when resolving unifiedClasspath.
             copiedConf.setCanBeConsumed(true);
             // Since we only depend on these from the same project (via CONSISTENT_VERSIONS_PRODUCTION or

--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -230,7 +230,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
         // Create "platform" configuration in root project, which will hold the strictConstraints
         NamedDomainObjectProvider<Configuration> gcvLocksConfiguration = project.getConfigurations()
                 .register("gcvLocks", conf -> {
-                    getGcvAttributes().configureGcvBaseAttributes(conf);
+                    conf.attributes(getGcvAttributes()::configureGcvBaseAttributes);
                     conf.getOutgoing().capability(GCV_LOCKS_CAPABILITY);
                     conf.setCanBeResolved(false);
                     conf.setVisible(false);
@@ -240,7 +240,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
                 (ProjectDependency) project.getDependencies().create(project);
         locksDependency.capabilities(moduleDependencyCapabilitiesHandler ->
                 moduleDependencyCapabilitiesHandler.requireCapabilities(GCV_LOCKS_CAPABILITY));
-        getGcvAttributes().configureGcvBaseAttributes(locksDependency);
+        locksDependency.attributes(getGcvAttributes()::configureGcvBaseAttributes);
 
         // This is a "marker" task that does nothing, it exists solely that we can detect if it has been run and so
         // write the versions lock task without running --write-locks code from any other gradle plugin. Unfortunately,
@@ -397,7 +397,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false).setCanBeResolved(false);
 
             // Make sure it can never be selected as part of normal resolution that declares a required usage.
-            getGcvAttributes().configureGcvBaseAttributes(conf);
+            conf.attributes(getGcvAttributes()::configureGcvBaseAttributes);
 
             // Mark it as a GCV_SOURCE, so that when we resolve {@link #UNIFIED_CLASSPATH_CONFIGURATION_NAME}
             // it becomes selected (as the best matching configuration) for the user's normal inter-project dependencies
@@ -411,7 +411,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false); // needn't be visible from other projects
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);
-            getGcvAttributes().configureGcvBaseAttributes(conf);
+            conf.attributes(getGcvAttributes()::configureGcvBaseAttributes);
             conf.getOutgoing().capability(capabilityFor(project, GcvScope.PRODUCTION));
         });
 
@@ -420,7 +420,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
             conf.setVisible(false); // needn't be visible from other projects
             conf.setCanBeConsumed(true);
             conf.setCanBeResolved(false);
-            getGcvAttributes().configureGcvBaseAttributes(conf);
+            conf.attributes(getGcvAttributes()::configureGcvBaseAttributes);
             conf.getOutgoing().capability(capabilityFor(project, GcvScope.TEST));
         });
 
@@ -654,7 +654,7 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
                         ImmutableList.copyOf(copiedConf.getAllDependencyConstraints()));
             }
 
-            getGcvAttributes().configureGcvBaseAttributes(copiedConf);
+            copiedConf.attributes(getGcvAttributes()::configureGcvBaseAttributes);
 
             // Must set this because we depend on this configuration when resolving unifiedClasspath.
             copiedConf.setCanBeConsumed(true);

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.versions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvBuildPath;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -67,6 +68,8 @@ public class VersionsPropsPlugin implements Plugin<Project> {
         // must be 'compatible with' (or the same as) the one for the VersionsLockPlugin's own configurations.
         Usage gcvVersionsPropsUsage =
                 project.getObjects().named(Usage.class, ConsistentVersionsPlugin.CONSISTENT_VERSIONS_USAGE);
+        GcvBuildPath gcvBuildPath = project.getObjects()
+                .named(GcvBuildPath.class, project.getRootProject().getBuildTreePath());
         String gcvVersionsPropsCapability = "gcv:versions-props:0";
 
         VersionsProps versionsProps = getVersionsProps(project.getRootProject());
@@ -104,6 +107,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
             // Create "platform" configuration in root project, which will hold the versions props constraints
             project.getConfigurations().register(GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME, conf -> {
                 conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, gcvVersionsPropsUsage);
+                conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
                 conf.getOutgoing().capability(gcvVersionsPropsCapability);
                 conf.setCanBeResolved(false);
                 conf.setCanBeConsumed(true);
@@ -125,7 +129,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                     // Wire in the constraints from the main configuration.
                     conf.getDependencies()
                             .add(createDepOnRootConstraintsConfiguration(
-                                    project, gcvVersionsPropsUsage, gcvVersionsPropsCapability));
+                                    project, gcvVersionsPropsUsage, gcvVersionsPropsCapability, gcvBuildPath));
                 });
 
         project.getConfigurations().configureEach(conf -> {
@@ -142,11 +146,12 @@ public class VersionsPropsPlugin implements Plugin<Project> {
     }
 
     private static ProjectDependency createDepOnRootConstraintsConfiguration(
-            Project project, Usage usage, String capability) {
+            Project project, Usage usage, String capability, GcvBuildPath gcvBuildPath) {
         ProjectDependency projectDep =
                 ((ProjectDependency) project.getDependencies().create(project.getRootProject()));
         projectDep.capabilities(capabilities -> capabilities.requireCapability(capability));
-        projectDep.attributes(attrs -> attrs.attribute(Usage.USAGE_ATTRIBUTE, usage));
+        projectDep.attributes(
+                attrs -> attrs.attribute(Usage.USAGE_ATTRIBUTE, usage).attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath));
         return projectDep;
     }
 

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -102,7 +102,7 @@ public abstract class VersionsPropsPlugin implements Plugin<Project> {
 
             // Create "platform" configuration in root project, which will hold the versions props constraints
             project.getConfigurations().register(GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME, conf -> {
-                getGcvAttributes().configureGcvBaseAttributes(conf);
+                conf.attributes(getGcvAttributes()::configureGcvBaseAttributes);
                 conf.getOutgoing().capability(gcvVersionsPropsCapability);
                 conf.setCanBeResolved(false);
                 conf.setCanBeConsumed(true);
@@ -145,7 +145,7 @@ public abstract class VersionsPropsPlugin implements Plugin<Project> {
         ProjectDependency projectDep =
                 ((ProjectDependency) project.getDependencies().create(project.getRootProject()));
         projectDep.capabilities(capabilities -> capabilities.requireCapability(capability));
-        gcvAttributes.configureGcvBaseAttributes(projectDep);
+        projectDep.attributes(gcvAttributes::configureGcvBaseAttributes);
         return projectDep;
     }
 

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -19,7 +19,7 @@ package com.palantir.gradle.versions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvAsGradleUsage;
+import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvAttributes;
 import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvBuildPath;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -61,13 +61,8 @@ public abstract class VersionsPropsPlugin implements Plugin<Project> {
     private static final String GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME = "gcvVersionsPropsConstraints";
     private static final String VERSION_PROPS_EXTENSION = "versionsProps";
 
-    // Shared across root project / other project
-    // This must be usable during VersionsLockPlugin's resolution of unifiedClasspath, so the usage
-    // must be 'compatible with' (or the same as) the one for the VersionsLockPlugin's own configurations.
-    private static final Usage GCV_VERSIONS_PROPS_USAGE = GcvAsGradleUsage.INSTANCE;
-
     @Nested
-    public abstract GcvBuildPath getGcvBuildPath();
+    public abstract GcvAttributes getGcvAttributes();
 
     @Override
     public final void apply(Project project) {
@@ -109,8 +104,10 @@ public abstract class VersionsPropsPlugin implements Plugin<Project> {
 
             // Create "platform" configuration in root project, which will hold the versions props constraints
             project.getConfigurations().register(GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME, conf -> {
-                conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GCV_VERSIONS_PROPS_USAGE);
-                conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
+                conf.getAttributes()
+                        .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
+                conf.getAttributes()
+                        .attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
                 conf.getOutgoing().capability(gcvVersionsPropsCapability);
                 conf.setCanBeResolved(false);
                 conf.setCanBeConsumed(true);
@@ -132,7 +129,10 @@ public abstract class VersionsPropsPlugin implements Plugin<Project> {
                     // Wire in the constraints from the main configuration.
                     conf.getDependencies()
                             .add(createDepOnRootConstraintsConfiguration(
-                                    project, GCV_VERSIONS_PROPS_USAGE, gcvVersionsPropsCapability, getGcvBuildPath()));
+                                    project,
+                                    getGcvAttributes().gradleUsageForGcv(),
+                                    gcvVersionsPropsCapability,
+                                    getGcvAttributes().buildPath()));
                 });
 
         project.getConfigurations().configureEach(conf -> {

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.versions;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvAsGradleUsage;
 import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvBuildPath;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -46,11 +47,12 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.VariantVersionMappingStrategy;
 import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.util.GradleVersion;
 
-public class VersionsPropsPlugin implements Plugin<Project> {
+public abstract class VersionsPropsPlugin implements Plugin<Project> {
     private static final Logger log = Logging.getLogger(VersionsPropsPlugin.class);
     private static final String ROOT_CONFIGURATION_NAME = "rootConfiguration";
     private static final GradleVersion MINIMUM_GRADLE_VERSION = GradleVersion.version("5.2");
@@ -59,17 +61,18 @@ public class VersionsPropsPlugin implements Plugin<Project> {
     private static final String GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME = "gcvVersionsPropsConstraints";
     private static final String VERSION_PROPS_EXTENSION = "versionsProps";
 
+    // Shared across root project / other project
+    // This must be usable during VersionsLockPlugin's resolution of unifiedClasspath, so the usage
+    // must be 'compatible with' (or the same as) the one for the VersionsLockPlugin's own configurations.
+    private static final Usage GCV_VERSIONS_PROPS_USAGE = GcvAsGradleUsage.INSTANCE;
+
+    @Nested
+    public abstract GcvBuildPath getGcvBuildPath();
+
     @Override
     public final void apply(Project project) {
         checkPreconditions();
 
-        // Shared across root project / other project
-        // This must be usable during VersionsLockPlugin's resolution of unifiedClasspath, so the usage
-        // must be 'compatible with' (or the same as) the one for the VersionsLockPlugin's own configurations.
-        Usage gcvVersionsPropsUsage =
-                project.getObjects().named(Usage.class, ConsistentVersionsPlugin.CONSISTENT_VERSIONS_USAGE);
-        GcvBuildPath gcvBuildPath = project.getObjects()
-                .named(GcvBuildPath.class, project.getRootProject().getBuildTreePath());
         String gcvVersionsPropsCapability = "gcv:versions-props:0";
 
         VersionsProps versionsProps = getVersionsProps(project.getRootProject());
@@ -106,8 +109,8 @@ public class VersionsPropsPlugin implements Plugin<Project> {
 
             // Create "platform" configuration in root project, which will hold the versions props constraints
             project.getConfigurations().register(GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME, conf -> {
-                conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, gcvVersionsPropsUsage);
-                conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath);
+                conf.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, GCV_VERSIONS_PROPS_USAGE);
+                conf.getAttributes().attribute(GcvBuildPath.ATTRIBUTE, getGcvBuildPath());
                 conf.getOutgoing().capability(gcvVersionsPropsCapability);
                 conf.setCanBeResolved(false);
                 conf.setCanBeConsumed(true);
@@ -129,7 +132,7 @@ public class VersionsPropsPlugin implements Plugin<Project> {
                     // Wire in the constraints from the main configuration.
                     conf.getDependencies()
                             .add(createDepOnRootConstraintsConfiguration(
-                                    project, gcvVersionsPropsUsage, gcvVersionsPropsCapability, gcvBuildPath));
+                                    project, GCV_VERSIONS_PROPS_USAGE, gcvVersionsPropsCapability, getGcvBuildPath()));
                 });
 
         project.getConfigurations().configureEach(conf -> {

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -20,7 +20,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvAttributes;
-import com.palantir.gradle.versions.ConsistentVersionsPlugin.GcvBuildPath;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -38,7 +37,6 @@ import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ExternalDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.JavaPlugin;
@@ -104,10 +102,7 @@ public abstract class VersionsPropsPlugin implements Plugin<Project> {
 
             // Create "platform" configuration in root project, which will hold the versions props constraints
             project.getConfigurations().register(GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME, conf -> {
-                conf.getAttributes()
-                        .attribute(Usage.USAGE_ATTRIBUTE, getGcvAttributes().gradleUsageForGcv());
-                conf.getAttributes()
-                        .attribute(GcvBuildPath.ATTRIBUTE, getGcvAttributes().buildPath());
+                getGcvAttributes().configureGcvBaseAttributes(conf);
                 conf.getOutgoing().capability(gcvVersionsPropsCapability);
                 conf.setCanBeResolved(false);
                 conf.setCanBeConsumed(true);
@@ -129,10 +124,7 @@ public abstract class VersionsPropsPlugin implements Plugin<Project> {
                     // Wire in the constraints from the main configuration.
                     conf.getDependencies()
                             .add(createDepOnRootConstraintsConfiguration(
-                                    project,
-                                    getGcvAttributes().gradleUsageForGcv(),
-                                    gcvVersionsPropsCapability,
-                                    getGcvAttributes().buildPath()));
+                                    project, getGcvAttributes(), gcvVersionsPropsCapability));
                 });
 
         project.getConfigurations().configureEach(conf -> {
@@ -149,12 +141,11 @@ public abstract class VersionsPropsPlugin implements Plugin<Project> {
     }
 
     private static ProjectDependency createDepOnRootConstraintsConfiguration(
-            Project project, Usage usage, String capability, GcvBuildPath gcvBuildPath) {
+            Project project, GcvAttributes gcvAttributes, String capability) {
         ProjectDependency projectDep =
                 ((ProjectDependency) project.getDependencies().create(project.getRootProject()));
         projectDep.capabilities(capabilities -> capabilities.requireCapability(capability));
-        projectDep.attributes(
-                attrs -> attrs.attribute(Usage.USAGE_ATTRIBUTE, usage).attribute(GcvBuildPath.ATTRIBUTE, gcvBuildPath));
+        gcvAttributes.configureGcvBaseAttributes(projectDep);
         return projectDep;
     }
 

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -462,7 +462,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         def includedBuild = directory("included-build")
         settingsFile << """
             includeBuild '${includedBuild.name}'
-        """
+        """.stripIndent(true)
 
         // configure the included build
         file("settings.gradle", includedBuild) << """
@@ -470,7 +470,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
             
             include 'innerA'
             include 'innerB'
-        """
+        """.stripIndent(true)
 
         file ("build.gradle", includedBuild) << """
             buildscript {
@@ -517,7 +517,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
                 implementation 'org.slf4j:slf4j-api'
                 runtimeOnly 'ch.qos.logback:logback-classic:1.1.11' // brings in slf4j-api 1.7.22
             }
-        """
+        """.stripIndent(true)
 
         def innerB = directory("innerB", includedBuild)
         file("build.gradle", innerB) << """
@@ -526,7 +526,7 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
             dependencies {
                 implementation 'test-alignment:module-with-higher-version'
             }
-        """
+        """.stripIndent(true)
 
         file('versions.props', includedBuild) << """
             org.slf4j:slf4j-api = 1.7.25

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -483,9 +483,28 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
             }
             allprojects {
                 group 'com.palantir.included-build'
+                version '1.0.0'
                 
                 repositories {
                     maven { url "file:///${mavenRepo.getAbsolutePath()}" }
+                }
+            }
+            
+            subprojects {
+                apply plugin: 'java'
+                apply plugin: 'maven-publish'
+                publishing {
+                    repositories {
+                        maven {
+                            url = "${mavenRepo.absolutePath}"
+                        }
+                    }
+                    
+                    publications {
+                        maven(MavenPublication) {
+                            from components.java
+                        }
+                    }
                 }
             }
             
@@ -517,6 +536,24 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         // configure main build
         buildFile << """
             apply plugin: 'java'
+            
+            group 'com.palantir.main-build'
+            version '1.2.3'
+            
+            apply plugin: 'maven-publish'
+            publishing {
+                repositories {
+                    maven {
+                        url = "${mavenRepo.absolutePath}"
+                    }
+                }
+                
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
         
             dependencies {
                 implementation 'test-alignment:module-that-should-be-aligned-up'
@@ -554,6 +591,11 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         then: 'build succeeds'
         runTasks('--write-locks')
+
+        println runTasks(
+                ':publishMavenPublicationToMavenRepository',
+                ':included-build:innerA:publishMavenPublicationToMavenRepository',
+                ':included-build:innerB:publishMavenPublicationToMavenRepository').output
 
         and: 'root build: dependency is bumped - there is a difference in resolution between Gradle versions hence why we do not compare contents directly'
         String rootVersionsLock = file("versions.lock").text

--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -452,4 +452,116 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
         where:
         gradleVersionNumber << GRADLE_VERSIONS
     }
+
+
+    def "#gradleVersionNumber: works with included builds"() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
+        // add included build
+        def includedBuild = directory("included-build")
+        settingsFile << """
+            includeBuild '${includedBuild.name}'
+        """
+
+        // configure the included build
+        file("settings.gradle", includedBuild) << """
+            rootProject.name = 'included-build'
+            
+            include 'innerA'
+            include 'innerB'
+        """
+
+        file ("build.gradle", includedBuild) << """
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+            }            
+            plugins {
+                id '${PLUGIN_NAME}'
+            }
+            allprojects {
+                group 'com.palantir.included-build'
+                
+                repositories {
+                    maven { url "file:///${mavenRepo.getAbsolutePath()}" }
+                }
+            }
+            
+        """.stripIndent(true)
+        def innerA = directory("innerA", includedBuild)
+        file("build.gradle", innerA) << """
+            apply plugin: 'java'
+            
+            dependencies {
+                implementation 'org.slf4j:slf4j-api'
+                runtimeOnly 'ch.qos.logback:logback-classic:1.1.11' // brings in slf4j-api 1.7.22
+            }
+        """
+
+        def innerB = directory("innerB", includedBuild)
+        file("build.gradle", innerB) << """
+            apply plugin: 'java'
+            
+            dependencies {
+                implementation 'test-alignment:module-with-higher-version'
+            }
+        """
+
+        file('versions.props', includedBuild) << """
+            org.slf4j:slf4j-api = 1.7.25
+            test-alignment:* = 1.1
+        """.stripIndent(true)
+
+        // configure main build
+        buildFile << """
+            apply plugin: 'java'
+        
+            dependencies {
+                implementation 'test-alignment:module-that-should-be-aligned-up'
+            }
+        """.stripIndent(true)
+
+        file('versions.props') << """
+            test-alignment:* = 1.0
+        """.stripIndent(true)
+
+        expect:
+        runTasks('--write-locks')
+
+        and: 'inner versions lock is expected'
+        file("versions.lock", includedBuild).text == """\
+            # Run ./gradlew writeVersionsLocks to regenerate this file
+            ch.qos.logback:logback-classic:1.1.11 (1 constraints: 36052a3b)
+            org.slf4j:slf4j-api:1.7.25 (2 constraints: 7d12a137)
+            test-alignment:module-with-higher-version:1.1 (1 constraints: a6041b2c)
+        """.stripIndent(true)
+
+        and: 'root build: versions lock is expected'
+        file("versions.lock").text == """\
+            # Run ./gradlew writeVersionsLocks to regenerate this file
+            test-alignment:module-that-should-be-aligned-up:1.0 (1 constraints: a5041a2c)
+        """.stripIndent(true)
+
+        when: 'we add a dependencies on the inner build'
+        buildFile << """
+            dependencies {
+              implementation 'com.palantir.included-build:innerA'
+              implementation 'com.palantir.included-build:innerB'
+            }
+        """.stripIndent(true)
+
+        then: 'build succeeds'
+        runTasks('--write-locks')
+
+        and: 'root build: dependency is bumped - there is a difference in resolution between Gradle versions hence why we do not compare contents directly'
+        String rootVersionsLock = file("versions.lock").text
+        rootVersionsLock.contains "ch.qos.logback:logback-classic:1.1.11 (1 constraints: 36052a3b)"
+        rootVersionsLock.contains "test-alignment:module-that-should-be-aligned-up:1.1 (1 constraints: a5041a2c)"
+        rootVersionsLock.contains "test-alignment:module-with-higher-version:1.1 (1 constraints: a6041b2c)"
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
+    }
 }


### PR DESCRIPTION
## Before this PR
When you try to use GCV in both the main build and the included build, you either get:
* Gradle 7: incorrect resolution
* Gradle 8: errors where the main build is trying to consume the inner build's internal configurations used to calculate its lock state

```
project : (requested: 'project :' because: requested)
        Failures:
           - Could not resolve project :.
           - Module ':8-8-works-with-included-builds' has been rejected:
     Cannot select module with conflict on capability 'gcv:versions-props:0' also provided by [com.palantir.included-build:included-build:unspecified(gcvVersionsPropsConstraints)]
```

We should not be using the internal configurations of included builds. The way we should be thinking about included builds is to imagine if they were published jars in a separate repo and we were consuming the artifacts that way.

This is happening because Gradle is configuration and variant aware across included builds! (Which is cool, just a bit annoying in this instance).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

To that end, considering all of the configurations and dependencies we use are annotated with attributes pertaining to GCV. We can add another attribute that uniquely identifies a gradle build within the build tree. 

This leverages [`Project#getBuildTreePath`](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#getBuildTreePath()) which gets the unique path of a project within the entire hierarchy. This is added in `Gradle 8.3`, for versions below - `(7.6.4, 8.2)` - we fallback to using `GradleInternal#getIdentityPath().getPath()` which is the same thing (provided we call `getBuildTreePath` on the root project of the build in question.

This means that when GCV is requesting dependencies and configurations, it will narrow down the candidates to be only those produced by the current build instance. This allows `--write-locks` to succeed, and then normal variant selection can occur e.g. get `apiClasses` or `runtimeClasses` variant from the included build which is substituted.

### Utilities
* To make it a bit easier to see what's going on, we extract some sort of `Attribute` action applier which will apply the base set of attributes i.e. `org.gradle.usage=consistent-versions-usage` and `com.palantir.consistent-versions.build-path=<build-tree-path>` and it will apply it consistently to the things we care about.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

