### PR TITLE
Fix semantic merge conflict between included builds fix and versions.lock blank lines

### DIFF
--- a/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationSpec.groovy
@@ -575,15 +575,19 @@ class ConsistentVersionsPluginIntegrationSpec extends IntegrationSpec {
 
         and: 'inner versions lock is expected'
         file("versions.lock", includedBuild).text == """\
-            # Run ./gradlew writeVersionsLocks to regenerate this file
+            # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
+            
             ch.qos.logback:logback-classic:1.1.11 (1 constraints: 36052a3b)
+            
             org.slf4j:slf4j-api:1.7.25 (2 constraints: 7d12a137)
+            
             test-alignment:module-with-higher-version:1.1 (1 constraints: a6041b2c)
         """.stripIndent(true)
 
         and: 'root build: versions lock is expected'
         file("versions.lock").text == """\
-            # Run ./gradlew writeVersionsLocks to regenerate this file
+            # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
+            
             test-alignment:module-that-should-be-aligned-up:1.0 (1 constraints: a5041a2c)
         """.stripIndent(true)
 


### PR DESCRIPTION
## Before this PR

#1001  failed to release due to a test from https://github.com/palantir/gradle-consistent-versions/pull/1393 not having the updated the versions.lock format ([circle](https://app.circleci.com/pipelines/github/palantir/gradle-consistent-versions/4267/workflows/9ad991b3-de52-4133-8be9-31a467d8fdc6/jobs/15841/tests)). Since #1001 was not up-to-date with develop, it merged fine but then failed on CI.

## After this PR
==COMMIT_MSG==
Republish to fix publishing failing
==COMMIT_MSG==

Fix the test

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

