### PR TITLE
Only create checkOverbroadConstraints task if versions.lock plugin is applied

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/CheckOverbroadConstraints.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckOverbroadConstraints.java
@@ -43,7 +43,9 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -54,10 +56,12 @@ public abstract class CheckOverbroadConstraints extends DefaultTask {
     @Option(option = "fix", description = "Whether to apply the suggested fix to versions.props")
     public abstract Property<Boolean> getShouldFix();
 
-    @InputFile
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract RegularFileProperty getPropsFile();
 
-    @InputFile
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract RegularFileProperty getLockFile();
 
     public CheckOverbroadConstraints() {

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsTask.java
@@ -41,7 +41,9 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -80,7 +82,8 @@ public class CheckUnusedConstraintsTask extends DefaultTask {
         return classpath;
     }
 
-    @InputFile
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public final Property<RegularFile> getPropsFile() {
         return propsFileProperty;
     }

--- a/src/main/java/com/palantir/gradle/versions/ConflictSafeLockFile.java
+++ b/src/main/java/com/palantir/gradle/versions/ConflictSafeLockFile.java
@@ -50,6 +50,10 @@ final class ConflictSafeLockFile {
 
     /** Reads and returns the {@link LockState}. */
     public LockState readLocks() {
+        if (!Files.exists(lockfile)) {
+            return LockState.from(Stream.empty(), Stream.empty());
+        }
+
         try (Stream<String> linesStream = Files.lines(lockfile).filter(line -> !line.isBlank())) {
             List<String> lines =
                     linesStream.filter(line -> !line.trim().startsWith("#")).collect(Collectors.toList());

--- a/src/main/java/com/palantir/gradle/versions/VersionsProps.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsProps.java
@@ -52,6 +52,10 @@ public final class VersionsProps {
     }
 
     public static VersionsProps loadFromFile(Path path) {
+        if (!Files.exists(path)) {
+            return VersionsProps.empty();
+        }
+
         List<String> lines = safeReadLines(path);
         return fromLines(lines, path);
     }

--- a/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsPropsPlugin.java
@@ -91,14 +91,20 @@ public abstract class VersionsPropsPlugin implements Plugin<Project> {
                     });
             project.getTasks().named("check").configure(task -> task.dependsOn(checkNoUnusedConstraints));
 
-            TaskProvider<CheckOverbroadConstraints> checkOverbroadConstraints = project.getTasks()
-                    .register("checkOverbroadConstraints", CheckOverbroadConstraints.class, task -> {
-                        task.getLockFile()
-                                .set(project.getLayout().getProjectDirectory().file("versions.lock"));
-                        task.getPropsFile()
-                                .set(project.getLayout().getProjectDirectory().file("versions.props"));
-                    });
-            project.getTasks().named("check").configure(task -> task.dependsOn(checkOverbroadConstraints));
+            project.getPluginManager().withPlugin("com.palantir.versions-lock", _plugin -> {
+                TaskProvider<CheckOverbroadConstraints> checkOverbroadConstraints = project.getTasks()
+                        .register("checkOverbroadConstraints", CheckOverbroadConstraints.class, task -> {
+                            task.getLockFile()
+                                    .set(project.getLayout()
+                                            .getProjectDirectory()
+                                            .file("versions.lock"));
+                            task.getPropsFile()
+                                    .set(project.getLayout()
+                                            .getProjectDirectory()
+                                            .file("versions.props"));
+                        });
+                project.getTasks().named("check").configure(task -> task.dependsOn(checkOverbroadConstraints));
+            });
 
             // Create "platform" configuration in root project, which will hold the versions props constraints
             project.getConfigurations().register(GCV_VERSIONS_PROPS_CONSTRAINTS_CONFIGURATION_NAME, conf -> {

--- a/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/versions/VersionsPropsPluginIntegrationSpec.groovy
@@ -286,6 +286,21 @@ class VersionsPropsPluginIntegrationSpec extends IntegrationSpec {
         gradleVersionNumber << GRADLE_VERSIONS
     }
 
+    def '#gradleVersionNumber: build succeeds without versions.props or versions.lock'() {
+        setup:
+        gradleVersion = gradleVersionNumber
+
+        addSubproject('foo', """
+            apply plugin: 'java'
+        """.stripIndent(true))
+
+        expect:
+        runTasks('build')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
+    }
+
     boolean verifyLockfile(File projectDir, String... lines) {
         // Gradle 7+ only uses a single lockfile per project:
         // https://docs.gradle.org/current/userguide/upgrading_version_6.html#locking_single


### PR DESCRIPTION
`checkOverbroadConstraints` uses `versions.lock` as an input, but this file won't exist if you applying just the `versions-props` plugin. 

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':checkOverbroadConstraints' (type 'CheckOverbroadConstraints').
  - In plugin 'com.palantir.gradle.versions.VersionsPropsPlugin_Decorated' type 'com.palantir.gradle.versions.CheckOverbroadConstraints' property 'lockFile' specifies file '/home/circleci/project/versions.lock' which doesn't exist.
    
    Reason: An input file was expected to be present but it doesn't exist.
    
    Possible solutions:
      1. Make sure the file exists before the task is called.
      2. Make sure that the task which produces the file is declared as an input.
```

This PR:
- Only creates the `checkOverbroadConstraints` task if the `versions-lock` plugin is applied.
- Allows the `versions-props` tasks to work properly even if `versions.props` and/or `verisons.lock` do not exist.