### PR TITLE
[Gradle 9] Ensure we don't break Gradle versions < 8.14

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/VersionsLockPlugin.java
@@ -665,8 +665,14 @@ public abstract class VersionsLockPlugin implements Plugin<Project> {
             // It works without this in Gradle 8
             // It is however *illegal* in Gradle 9, so we have to remove it.
             // When we drop Gradle 7
-            if (GradleVersion.current().compareTo(GradleVersion.version("8.0")) < 0) {
+            if (GradleVersion.current().compareTo(GradleVersion.version("8.14")) < 0) {
                 projectDep.getConfigurations().add(copiedTargetConfResolvable);
+                copiedTargetConfResolvable.outgoing(outgoing -> outgoing.capability(String.format(
+                        "gcv:%s-%s-%s-%s:extra",
+                        projectDep.getGroup(),
+                        projectDep.getName(),
+                        projectDep.getVersion(),
+                        copiedTargetConfResolvable.getName())));
             }
 
             Configuration copiedConf = projectDep

--- a/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
+++ b/src/test/groovy/com/palantir/gradle/versions/GradleTestVersions.java
@@ -22,5 +22,5 @@ public final class GradleTestVersions {
     private GradleTestVersions() {}
 
     public static final List<String> GRADLE_VERSIONS =
-            List.of(VersionsLockPlugin.MINIMUM_GRADLE_VERSION.getVersion(), "8.14.3", "9.1.0");
+            List.of(VersionsLockPlugin.MINIMUM_GRADLE_VERSION.getVersion(), "8.8", "8.14.3", "9.1.0");
 }


### PR DESCRIPTION
## Before this PR
If you're running on Gradle 8 but lower than 8.14.0, you will end up having an empty `versions.lock`. We did not catch this in #1443 because we were running with the latest version of Gradle - `8.14.3`. 

This is bad, because the PR will merge (assuming you don't try to do a `getVersions`) and you will have *no* constraints, and nothing is locked! Fortunately, ~93% of repositories we're tracking have made the migration to at least Gradle 8.14. So the blast radius is limited to a relatively small number of repositories.

I discovered this whilst trying to make similar Gradle 9 changes on [sls-packaging](https://github.com/palantir/sls-packaging). It was on Gradle 8.8 for some reason, and when GCV upgraded in that repo, the `versions.lock` was empty. It came back when I bumped the version of the wrapper to `8.14.3`.

Whilst debugging, it manifested when inspecting the root component and looking at the variant dependencies. The consumable configurations that we create that extend the copied configurations had _**no**_ dependencies! We don't add any dependencies directly to that configuration and the only way it gets its dependencies is from *extending* a *copy* of the locked configurations we care about.

Scanning through Gradle 8.14.0 release notes, the only thing that potentially stood out, but still felt quite far fetched was this change: 
* [Configurations are initialised lazily](https://docs.gradle.org/8.14/release-notes.html#configurations-are-initialized-lazily)

Upon closer inspection on the [PR](https://github.com/gradle/gradle/commit/21cdcf4e2ee4c7ac819911bc42b79f5bbdf5f249), in `DefaultLocalVariantGraphResolveStateBuilder` - the class that takes information from `Configuration` and constructs the internal dependency graph - we don't use the `ConfigurationsProvider#visitAll` method anymore, we get the `Configuration`s from the hierarchy, and extract the dependencies directly. Previously, we'd do `ConfigurationsProvider#visitAll` and do whatever filtering/extraction we'd need. 

The key difference is with `ConfigurationsProvider#visitAll` you are fetching all the elements **in** the `ConfigurationContainer`, and then for each configuration in the hierarchy, checking whether it exists in that set. Whereas in the new code, we take the hierarchy as is from the `Configuration` not checking that it exists in the given container.

Since copied `Configuration`s via `Configuration#copy(Recursive)?` are detached, they do not belong to the main `ConfigurationContainer` => when we want to extract the dependencies from the hierarchy, it doesn't appear in the filtered view. So if you are to extend a copied configuration (which is detached), you would need to add the fresh configuration to the `ConfigurationContainer`. But from Gradle 8.14 onwards, since we look at the hierarchy directly without filtering it through the lens of the `ConfigurationContainer`, no such action is necessary.

In Gradle 9, it is [forbidden](https://docs.gradle.org/current/userguide/upgrading_version_8.html#adding_to_configuration_container) to add a configuration directly to the `ConfigurationContainer`. It was deprecated in Gradle 8.11 and made an error in Gradle 9. We were already adding things into the `ConfigurationContainer` but we were constructing the `Configuration` in a Gradle 9 incompatible way. In #1443, I had previously limited the addition to just Gradle 7, but I hadn't noticed that we were failing on Gradle 8 < `8.13` as I had bumped the versions to test to `8.14.3`.

We need to also copy the capability logic that is supposed to resolve the following errors:

```
Could not determine the dependencies of task ':foo:compileJava'.
> Could not resolve all dependencies for configuration ':foo:compileClasspath'.
   > Could not resolve project :bar.
     Required by:
         project :foo
      > The consumer was configured to find a library for use during compile-time, compatible with Java 17, preferably in the form of class files, preferably optimized for standard JVMs, and its dependencies declared externally. However we cannot choose between the following variants of project :bar:
          - compileClasspathCopy
          - testCompileClasspathCopy
        All of them match the consumer attributes:
          - Variant 'compileClasspathCopy' capability '8-13-inter-project-normal-dependency-works:bar:unspecified' declares a library for use during compile-time, compatible with Java 17, preferably in the form of class files, preferably optimized for standard JVMs, and its dependencies declared externally
          - Variant 'testCompileClasspathCopy' capability '8-13-inter-project-normal-dependency-works:bar:unspecified' declares a library for use during compile-time, compatible with Java 17, preferably in the form of class files, preferably optimized for standard JVMs, and its dependencies declared externally
```

Which again was not an issue in versions >= `8.14.0`, because the copied configuration would be detached and would not participate in dependency resolution (at least for variant matching).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

* Test on 8.8
* Add the copied configuration to the container for every version up to 8.14
* Disambiguate the copied configurations by adding a capability that effectively uniquely identifies that configuration


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

