### PR TITLE
Bump gradle-idea-configuration plugin version

### DIFF
--- a/versions.lock
+++ b/versions.lock
@@ -2,13 +2,15 @@
 
 com.fasterxml.jackson.core:jackson-annotations:2.20 (4 constraints: 444484b1)
 
-com.fasterxml.jackson.core:jackson-core:2.20.0 (3 constraints: 8740c06e)
+com.fasterxml.jackson.core:jackson-core:2.20.0 (4 constraints: 8056ceff)
 
-com.fasterxml.jackson.core:jackson-databind:2.20.0 (3 constraints: 39335ae1)
+com.fasterxml.jackson.core:jackson-databind:2.20.0 (4 constraints: 32496639)
 
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.20.0 (1 constraints: 3605333b)
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.20.0 (2 constraints: da1f1fde)
 
-com.fasterxml.jackson.datatype:jackson-datatype-guava:2.20.0 (1 constraints: 3605333b)
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.20.0 (2 constraints: da1f1fde)
+
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.20.0 (1 constraints: a51a8b21)
 
 com.fasterxml.woodstox:woodstox-core:7.1.1 (1 constraints: 3d174926)
 
@@ -16,7 +18,7 @@ com.google.errorprone:error_prone_annotations:2.41.0 (2 constraints: 7e0f1fa1)
 
 com.google.guava:failureaccess:1.0.3 (1 constraints: 160ae3b4)
 
-com.google.guava:guava:33.5.0-jre (5 constraints: ec6d125a)
+com.google.guava:guava:33.5.0-jre (4 constraints: cc51abef)
 
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
 
@@ -24,7 +26,7 @@ com.google.j2objc:j2objc-annotations:3.1 (1 constraints: b809f1a0)
 
 com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions:1.2.0 (1 constraints: 0505f635)
 
-com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.3.0 (1 constraints: 0505f435)
+com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.7.0 (1 constraints: 09050036)
 
 one.util:streamex:0.8.4 (1 constraints: 0e050736)
 

--- a/versions.props
+++ b/versions.props
@@ -10,7 +10,7 @@ org.mockito:mockito-core = 5.20.0
 com.netflix.nebula:nebula-test = 10.6.2
 com.palantir.gradle.failure-reports:* = 1.2.0
 one.util:streamex = 0.8.4
-com.palantir.gradle.idea-configuration:gradle-idea-configuration = 0.3.0
+com.palantir.gradle.idea-configuration:gradle-idea-configuration = 0.7.0
 
 # Unnecessary once we have lock files
 com.google.code.findbugs:jsr305 = 3.0.2


### PR DESCRIPTION
## Before this PR
The gradle idea-configuration-plugin used by the project is outdated - using version 0.3.0 instead of the latest 0.7.0.

Although `classpath 'com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.7.0'` specifies the current latest version, projects using this plugin are failing with the following error:

```
...
> Task :writeMavenRepositories UP-TO-DATE
> Task :updateExternalDepsXml FAILED

[Incubating] Problems report is available at: file:///Users/hahn/workspace/4screen/location-poi-service/build/reports/problems/problems-report.html

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/9.1.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
8 actionable tasks: 5 executed, 3 up-to-date

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':updateExternalDepsXml'.
> groovy/util/XmlParser
```
This occurs with the combination of Intellij IDEA, Gradle 9 and palantir consistent-versions 3.4.0.

## After this PR
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?

