### PR TITLE
Use `getAllComponents()` instead of manual graph traversal in `checkUnusedConstraints`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-guava'
     implementation 'one.util:streamex'
     implementation 'com.palantir.gradle.idea-configuration:gradle-idea-configuration'
-    implementation 'com.palantir.gradle.utils:dependency-graph-utils'
 
     testImplementation platform('org.junit:junit-bom')
     testImplementation 'com.netflix.nebula:nebula-test'

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.versions;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.gradle.api.Plugin;
@@ -57,13 +58,13 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                         .filter(configuration -> !configuration.getName().startsWith("checkUnusedConstraints"))
                         .toList());
 
-        Provider<Map<String, ResolvedComponentResult>> configurationNameToRootComponents =
+        Provider<Map<String, Set<ResolvedComponentResult>>> configurationNameToRootComponents =
                 configurationsToCheck.map(configurations -> configurations.stream()
                         .collect(Collectors.toMap(
                                 configuration -> configuration.getName(), configuration -> configuration
                                         .getIncoming()
                                         .getResolutionResult()
-                                        .getRoot())));
+                                        .getAllComponents())));
 
         Provider<List<FileCollection>> resolvedFiles =
                 configurationsToCheck.map(configurations -> configurations.stream()

--- a/src/main/java/com/palantir/gradle/versions/WriteResolvedCoordinatesTask.java
+++ b/src/main/java/com/palantir/gradle/versions/WriteResolvedCoordinatesTask.java
@@ -18,10 +18,10 @@ package com.palantir.gradle.versions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.palantir.gradle.utils.dependencygraph.DependencyGraphUtils;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.Set;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
@@ -48,12 +48,12 @@ public abstract class WriteResolvedCoordinatesTask extends DefaultTask {
     public abstract ConfigurableFileCollection getResolvedFiles();
 
     @Input
-    public abstract MapProperty<String, ResolvedComponentResult> getConfigurationNameToRootComponents();
+    public abstract MapProperty<String, Set<ResolvedComponentResult>> getConfigurationNameToRootComponents();
 
     @TaskAction
     public final void writeResolvedCoordinates() {
         List<ResolvedCoordinate> sorted = getConfigurationNameToRootComponents().get().entrySet().stream()
-                .flatMap(entry -> DependencyGraphUtils.allComponentResultsFromRoot(entry.getValue()).stream()
+                .flatMap(entry -> entry.getValue().stream()
                         .map(ResolvedComponentResult::getId)
                         .filter(ModuleComponentIdentifier.class::isInstance)
                         .map(ModuleComponentIdentifier.class::cast)

--- a/versions.lock
+++ b/versions.lock
@@ -28,8 +28,6 @@ com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions:1.2.0 (1 c
 
 com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.7.0 (1 constraints: 09050036)
 
-com.palantir.gradle.utils:dependency-graph-utils:0.22.0 (1 constraints: 36052d3b)
-
 one.util:streamex:0.8.4 (1 constraints: 0e050736)
 
 org.codehaus.woodstox:stax2-api:4.2.2 (2 constraints: 6a278bd2)

--- a/versions.props
+++ b/versions.props
@@ -12,7 +12,6 @@ com.netflix.nebula:nebula-test = 10.6.2
 com.palantir.gradle.failure-reports:* = 1.2.0
 one.util:streamex = 0.8.4
 com.palantir.gradle.idea-configuration:gradle-idea-configuration = 0.7.0
-com.palantir.gradle.utils:dependency-graph-utils = 0.22.0
 
 # Unnecessary once we have lock files
 com.google.code.findbugs:jsr305 = 3.0.2


### PR DESCRIPTION
## Before this PR

The `WriteResolvedCoordinatesTask` used `DependencyGraphUtils.allComponentResultsFromRoot()` to walk the dependency graph from each configuration's root component. This method throws on any `UnresolvedDependencyResult`, causing `checkUnusedConstraints` to fail in projects that have unresolvable dependencies.

The old inline implementation in `CheckUnusedConstraintsTask.getResolvedModuleIdentifiers` used `ResolutionResult.getAllComponents()` which is lenient — it only returns successfully resolved components and silently omits unresolved ones see:

```java
    public static void eachElement(
        ResolvedComponentResult start,
        Action<? super ResolvedComponentResult> moduleAction,
        Action<? super DependencyResult> dependencyAction,
        Set<ResolvedComponentResult> visited
    ) {
        if (!visited.add(start)) {
            return;
        }
        moduleAction.execute(start);
        for (DependencyResult d : start.getDependencies()) {
            dependencyAction.execute(d);
            if (d instanceof ResolvedDependencyResult) {
                eachElement(((ResolvedDependencyResult) d).getSelected(), moduleAction, dependencyAction, visited);
            }
        }
    }
```

## After this PR

Uses `ResolutionResult.getAllComponents()` instead of manual graph traversal, restoring the lenient behaviour. This also removes the `dependency-graph-utils` dependency which is no longer needed.

This is fine todo as we are wrapping in a provider anyway so the resolution is still lazy (we were using `getRoot` previously which is not lazy anyway)

## Possible downsides?

## Testing

Existing tests cover `checkUnusedConstraints` behavior.