### PR TITLE
Filter artifact view to `ModuleComponentIdentifier` in `checkUnusedConstraints`

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
@@ -70,7 +71,10 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                 configurationsToCheck.map(configurations -> configurations.stream()
                         .map(configuration -> configuration
                                 .getIncoming()
-                                .artifactView(view -> view.lenient(true))
+                                .artifactView(view -> {
+                                    view.lenient(true);
+                                    view.componentFilter(id -> !(id instanceof ProjectComponentIdentifier));
+                                })
                                 .getFiles())
                         .collect(Collectors.toList()));
 

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -26,7 +26,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
@@ -73,7 +73,7 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                                 .getIncoming()
                                 .artifactView(view -> {
                                     view.lenient(true);
-                                    view.componentFilter(id -> !(id instanceof ProjectComponentIdentifier));
+                                    view.componentFilter(id -> (id instanceof ModuleComponentIdentifier));
                                 })
                                 .getFiles())
                         .collect(Collectors.toList()));

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -73,7 +73,7 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                                 .getIncoming()
                                 .artifactView(view -> {
                                     view.lenient(true);
-                                    view.componentFilter(id -> (id instanceof ModuleComponentIdentifier));
+                                    view.componentFilter(ModuleComponentIdentifier.class::isInstance);
                                 })
                                 .getFiles())
                         .collect(Collectors.toList()));

--- a/src/test/java/com/palantir/gradle/versions/CheckUnusedConstraintIntegrationTest.java
+++ b/src/test/java/com/palantir/gradle/versions/CheckUnusedConstraintIntegrationTest.java
@@ -250,6 +250,41 @@ class CheckUnusedConstraintIntegrationTest {
         assertThat(result).task(":checkUnusedConstraints").succeeded();
     }
 
+    @Test
+    void checkUnusedConstraints_does_not_depend_on_project_jar_tasks(
+            GradleInvoker gradle, RootProject rootProject, SubProject lib) {
+        rootProject.file("versions.props").overwrite("""
+            com.google.guava:guava = 33.0.0-jre
+            """);
+
+        lib.buildGradle().plugins().add("java-library");
+        lib.buildGradle().append("""
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                api 'com.google.guava:guava'
+            }
+            """);
+
+        rootProject.buildGradle().plugins().add("java-library");
+        rootProject.buildGradle().append("""
+            dependencies {
+                api project(':lib')
+            }
+            """);
+
+        // Without the componentFilter fix, the artifact view includes project jars which
+        // causes writeResolvedCoordinatesTask to unnecessarily depend on :lib:jar.
+        // With the fix, project components are filtered out so :lib:jar is not triggered.
+        InvocationResult result =
+                gradle.withArgs("checkUnusedConstraints", "--parallel").buildsSuccessfully();
+        assertThat(result)
+                .output()
+                .as("writeResolvedCoordinatesTask should not trigger :lib:jar")
+                .doesNotContain(":lib:jar");
+    }
+
     private static String pomWithJarPackaging(String group, String artifact, String version) {
         return """
             <?xml version="1.0" encoding="UTF-8"?>

--- a/src/test/java/com/palantir/gradle/versions/CheckUnusedConstraintIntegrationTest.java
+++ b/src/test/java/com/palantir/gradle/versions/CheckUnusedConstraintIntegrationTest.java
@@ -281,7 +281,7 @@ class CheckUnusedConstraintIntegrationTest {
                 gradle.withArgs("checkUnusedConstraints", "--parallel").buildsSuccessfully();
         assertThat(result)
                 .output()
-                .as("writeResolvedCoordinatesTask should not trigger :lib:jar")
+                .as("checkUnusedConstraints should not trigger :lib:jar")
                 .doesNotContain(":lib:jar");
     }
 


### PR DESCRIPTION
## Before this PR

In multi-project builds with inter-project dependencies, `checkUnusedConstraints` fails because `writeResolvedCoordinatesTask` uses the output of subproject `:jar` tasks (the resolved artifact JARs) without declaring an explicit dependency on them. Gradle detects this implicit dependency and fails the build with:

```
Task ':writeResolvedCoordinatesTask' uses this output of task ':some-subproject:jar'
without declaring an explicit or implicit dependency.
```

This was introduced in #1573 which changed the resolved files input to use an artifact view. The artifact view resolves files for _all_ components including project dependencies, which produces JAR files from other subprojects. 

## After this PR

Adds a `componentFilter` to the artifact view that filters to only `ModuleComponentIdentifier` components, matching the downstream filtering in `WriteResolvedCoordinatesTask`. This is safe because:

1. The `componentFilter` operates at the artifact selection level, not graph resolution — Gradle must fully resolve the configuration's dependency graph before applying the filter, so the task ordering that prevents parallel resolution lock errors is preserved
2. `WriteResolvedCoordinatesTask` already filters to only `ModuleComponentIdentifier` when extracting coordinates — project components would be skipped anyway
3. Project dependencies are not version-constrained via `versions.props`, so they're irrelevant to the unused constraints check

The filter removes the implicit build task dependency on project `:jar` tasks (fixing the error) while preserving the configuration resolution ordering needed for correct parallel execution.

## Possible downsides?