### PR TITLE
Stop downloading artifacts in `checkUnusedConstraints` resolution ordering

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -72,6 +72,10 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                                 .getIncoming()
                                 .artifactView(view -> {
                                     view.lenient(true);
+                                    // Exclude all components so no artifact files are downloaded.
+                                    // The artifact view still triggers dependency graph resolution
+                                    // (the filter is applied after resolution), which is all we need
+                                    // for cross-project locking with --parallel on Gradle 9+.
                                     view.componentFilter(_id -> false);
                                 })
                                 .getFiles())

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -26,7 +26,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
@@ -73,7 +72,7 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                                 .getIncoming()
                                 .artifactView(view -> {
                                     view.lenient(true);
-                                    view.componentFilter(ModuleComponentIdentifier.class::isInstance);
+                                    view.componentFilter(_id -> false);
                                 })
                                 .getFiles())
                         .collect(Collectors.toList()));

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -58,7 +58,7 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                         .filter(configuration -> !configuration.getName().startsWith("checkUnusedConstraints"))
                         .toList());
 
-        Provider<Map<String, Set<ResolvedComponentResult>>> configurationNameToRootComponents =
+        Provider<Map<String, Set<ResolvedComponentResult>>> configurationNameToAllComponents =
                 configurationsToCheck.map(configurations -> configurations.stream()
                         .collect(Collectors.toMap(
                                 configuration -> configuration.getName(), configuration -> configuration
@@ -86,7 +86,7 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                     task.getOutputFile()
                             .fileValue(new File(task.getTemporaryDir(), "resolved-module-identifiers.json"));
                     task.getResolvedFiles().from(resolvedFiles);
-                    task.getConfigurationNameToRootComponents().putAll(configurationNameToRootComponents);
+                    task.getConfigurationNameToRootComponents().putAll(configurationNameToAllComponents);
                 });
 
         getConfigurations().register("checkUnusedConstraintsConsumable", consumable -> {

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -86,7 +86,7 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                     task.getOutputFile()
                             .fileValue(new File(task.getTemporaryDir(), "resolved-module-identifiers.json"));
                     task.getResolvedFiles().from(resolvedFiles);
-                    task.getConfigurationNameToRootComponents().putAll(configurationNameToAllComponents);
+                    task.getConfigurationNameToAllComponents().putAll(configurationNameToAllComponents);
                 });
 
         getConfigurations().register("checkUnusedConstraintsConsumable", consumable -> {

--- a/src/main/java/com/palantir/gradle/versions/WriteResolvedCoordinatesTask.java
+++ b/src/main/java/com/palantir/gradle/versions/WriteResolvedCoordinatesTask.java
@@ -48,11 +48,11 @@ public abstract class WriteResolvedCoordinatesTask extends DefaultTask {
     public abstract ConfigurableFileCollection getResolvedFiles();
 
     @Input
-    public abstract MapProperty<String, Set<ResolvedComponentResult>> getConfigurationNameToRootComponents();
+    public abstract MapProperty<String, Set<ResolvedComponentResult>> getConfigurationNameToAllComponents();
 
     @TaskAction
     public final void writeResolvedCoordinates() {
-        List<ResolvedCoordinate> sorted = getConfigurationNameToRootComponents().get().entrySet().stream()
+        List<ResolvedCoordinate> sorted = getConfigurationNameToAllComponents().get().entrySet().stream()
                 .flatMap(entry -> entry.getValue().stream()
                         .map(ResolvedComponentResult::getId)
                         .filter(ModuleComponentIdentifier.class::isInstance)


### PR DESCRIPTION
## Before this PR

The `writeResolvedCoordinatesTask` in #1573 used `@InputFiles` with an artifact view filtered to `ModuleComponentIdentifier` to establish cross-project resolution ordering for `--parallel` on Gradle 9. This works correctly for locking, but the artifact view with `componentFilter(ModuleComponentIdentifier.class::isInstance)` selects all external module artifacts, causing Gradle to **download every JAR** from every resolvable configuration (compileClasspath, runtimeClasspath, devEnv, custom configurations, etc.).

This caused significant performance regression:
- Tasks that previously took 7-20 seconds (metadata-only resolution) now take 40-50+ seconds
- The actual task logic only needs the dependency graph metadata (module coordinates), not the artifact files

## After this PR

Changes the `componentFilter` from `ModuleComponentIdentifier.class::isInstance` (selects all external module artifacts → downloads JARs) to `_id -> false` (selects nothing → downloads no artifacts).

The `@InputFiles` file collection is still evaluated by Gradle during input fingerprinting, which triggers dependency graph resolution with proper cross-project locking. The component filter is applied *after* the graph is resolved, so even though no components are selected (and no files are downloaded), the resolution still happens — establishing the ordering needed for `--parallel` on Gradle 9.

The `@Input MapProperty<String, Set<ResolvedComponentResult>>` then provides the actual dependency graph data. Since the graph was already resolved via the `@InputFiles` evaluation, the `getAllComponents()` calls return cached results.

## Possible downsides?

The `@InputFiles` file collection will always be empty (since `componentFilter(_id -> false)` matches nothing). This means Gradle's up-to-date checking for this input will always see "no files" — but the `@Input` with `ResolvedComponentResult` objects still provides proper change detection for the dependency graph.