### PR TITLE
Remove `resolvedFiles` to prevent resolving of files

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -72,6 +72,10 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                                 .getIncoming()
                                 .artifactView(view -> {
                                     view.lenient(true);
+                                    // Exclude all components so no artifact files are downloaded.
+                                    // The artifact view still triggers dependency graph resolution
+                                    // (the filter is applied after resolution), which is all we need
+                                    // for cross-project locking with --parallel on Gradle 9+.
                                     view.componentFilter(_id -> false);
                                 })
                                 .getFiles())

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -26,7 +26,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
@@ -73,7 +72,7 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                                 .getIncoming()
                                 .artifactView(view -> {
                                     view.lenient(true);
-                                    view.componentFilter(ModuleComponentIdentifier.class::isInstance);
+                                    view.componentFilter(_id -> false);
                                 })
                                 .getFiles())
                         .collect(Collectors.toList()));

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -28,7 +28,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -66,26 +65,10 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                                         .getResolutionResult()
                                         .getAllComponents())));
 
-        Provider<List<FileCollection>> resolvedFiles =
-                configurationsToCheck.map(configurations -> configurations.stream()
-                        .map(configuration -> configuration
-                                .getIncoming()
-                                .artifactView(view -> {
-                                    view.lenient(true);
-                                    // Exclude all components so no artifact files are downloaded.
-                                    // The artifact view still triggers dependency graph resolution
-                                    // (the filter is applied after resolution), which is all we need
-                                    // for cross-project locking with --parallel on Gradle 9+.
-                                    view.componentFilter(_id -> false);
-                                })
-                                .getFiles())
-                        .collect(Collectors.toList()));
-
         TaskProvider<WriteResolvedCoordinatesTask> writeResolvedCoordinatesTask = getTasks()
                 .register("writeResolvedCoordinatesTask", WriteResolvedCoordinatesTask.class, task -> {
                     task.getOutputFile()
                             .fileValue(new File(task.getTemporaryDir(), "resolved-module-identifiers.json"));
-                    task.getResolvedFiles().from(resolvedFiles);
                     task.getConfigurationNameToAllComponents().putAll(configurationNameToAllComponents);
                 });
 

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -58,7 +58,7 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                         .filter(configuration -> !configuration.getName().startsWith("checkUnusedConstraints"))
                         .toList());
 
-        Provider<Map<String, Set<ResolvedComponentResult>>> configurationNameToRootComponents =
+        Provider<Map<String, Set<ResolvedComponentResult>>> configurationNameToAllComponents =
                 configurationsToCheck.map(configurations -> configurations.stream()
                         .collect(Collectors.toMap(
                                 configuration -> configuration.getName(), configuration -> configuration
@@ -86,7 +86,7 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                     task.getOutputFile()
                             .fileValue(new File(task.getTemporaryDir(), "resolved-module-identifiers.json"));
                     task.getResolvedFiles().from(resolvedFiles);
-                    task.getConfigurationNameToRootComponents().putAll(configurationNameToRootComponents);
+                    task.getConfigurationNameToRootComponents().putAll(configurationNameToAllComponents);
                 });
 
         getConfigurations().register("checkUnusedConstraintsConsumable", consumable -> {

--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -86,7 +86,7 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                     task.getOutputFile()
                             .fileValue(new File(task.getTemporaryDir(), "resolved-module-identifiers.json"));
                     task.getResolvedFiles().from(resolvedFiles);
-                    task.getConfigurationNameToRootComponents().putAll(configurationNameToAllComponents);
+                    task.getConfigurationNameToAllComponents().putAll(configurationNameToAllComponents);
                 });
 
         getConfigurations().register("checkUnusedConstraintsConsumable", consumable -> {

--- a/src/main/java/com/palantir/gradle/versions/WriteResolvedCoordinatesTask.java
+++ b/src/main/java/com/palantir/gradle/versions/WriteResolvedCoordinatesTask.java
@@ -25,14 +25,10 @@ import java.util.Set;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
 public abstract class WriteResolvedCoordinatesTask extends DefaultTask {
@@ -41,11 +37,6 @@ public abstract class WriteResolvedCoordinatesTask extends DefaultTask {
 
     @OutputFile
     public abstract RegularFileProperty getOutputFile();
-
-    /** Resolved files from all resolvable configurations — establishes cross-project task ordering. */
-    @InputFiles
-    @PathSensitive(PathSensitivity.NONE)
-    public abstract ConfigurableFileCollection getResolvedFiles();
 
     @Input
     public abstract MapProperty<String, Set<ResolvedComponentResult>> getConfigurationNameToAllComponents();

--- a/src/main/java/com/palantir/gradle/versions/WriteResolvedCoordinatesTask.java
+++ b/src/main/java/com/palantir/gradle/versions/WriteResolvedCoordinatesTask.java
@@ -48,11 +48,11 @@ public abstract class WriteResolvedCoordinatesTask extends DefaultTask {
     public abstract ConfigurableFileCollection getResolvedFiles();
 
     @Input
-    public abstract MapProperty<String, Set<ResolvedComponentResult>> getConfigurationNameToRootComponents();
+    public abstract MapProperty<String, Set<ResolvedComponentResult>> getConfigurationNameToAllComponents();
 
     @TaskAction
     public final void writeResolvedCoordinates() {
-        List<ResolvedCoordinate> sorted = getConfigurationNameToRootComponents().get().entrySet().stream()
+        List<ResolvedCoordinate> sorted = getConfigurationNameToAllComponents().get().entrySet().stream()
                 .flatMap(entry -> entry.getValue().stream()
                         .map(ResolvedComponentResult::getId)
                         .filter(ModuleComponentIdentifier.class::isInstance)


### PR DESCRIPTION
## Before this PR
We used to have `resolvedFiles`  to ensure task ordering but this would resolve all files making the build much slower


<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
This have removed `resolvedFiles` - this was only needed due to bad design in other plugins for Gradle 9. The correct solution is to fix this in the other plugins

Correctly rename `getConfigurationNameToRootComponents` to `getConfigurationNameToAllComponents`
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

