### PR TITLE
Fix OOM in `writeResolvedCoordinatesTask` by avoiding serialisation of full resolution graph

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -18,7 +18,6 @@ package com.palantir.gradle.versions;
 
 import java.io.File;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -26,7 +25,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
@@ -57,19 +56,21 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
                         .filter(configuration -> !configuration.getName().startsWith("checkUnusedConstraints"))
                         .toList());
 
-        Provider<Map<String, Set<ResolvedComponentResult>>> configurationNameToAllComponents =
+        Provider<Set<ResolvedCoordinate>> resolvedCoordinates =
                 configurationsToCheck.map(configurations -> configurations.stream()
-                        .collect(Collectors.toMap(
-                                configuration -> configuration.getName(), configuration -> configuration
-                                        .getIncoming()
-                                        .getResolutionResult()
-                                        .getAllComponents())));
+                        .flatMap(configuration ->
+                                configuration.getIncoming().getResolutionResult().getAllComponents().stream()
+                                        .filter(component -> component.getId() instanceof ModuleComponentIdentifier)
+                                        .map(component -> (ModuleComponentIdentifier) component.getId())
+                                        .map(mcid -> ResolvedCoordinate.of(
+                                                configuration.getName(), mcid.getGroup(), mcid.getModule())))
+                        .collect(Collectors.toSet()));
 
         TaskProvider<WriteResolvedCoordinatesTask> writeResolvedCoordinatesTask = getTasks()
                 .register("writeResolvedCoordinatesTask", WriteResolvedCoordinatesTask.class, task -> {
                     task.getOutputFile()
                             .fileValue(new File(task.getTemporaryDir(), "resolved-module-identifiers.json"));
-                    task.getConfigurationNameToAllComponents().putAll(configurationNameToAllComponents);
+                    task.getResolvedCoordinates().addAll(resolvedCoordinates);
                 });
 
         getConfigurations().register("checkUnusedConstraintsConsumable", consumable -> {

--- a/src/main/java/com/palantir/gradle/versions/ResolvedCoordinate.java
+++ b/src/main/java/com/palantir/gradle/versions/ResolvedCoordinate.java
@@ -25,7 +25,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableResolvedCoordinate.class)
 @JsonDeserialize(as = ImmutableResolvedCoordinate.class)
-public interface ResolvedCoordinate extends Serializable, Comparable<ResolvedCoordinate> {
+interface ResolvedCoordinate extends Serializable, Comparable<ResolvedCoordinate> {
     Comparator<ResolvedCoordinate> COMPARATOR = Comparator.comparing(ResolvedCoordinate::configuration)
             .thenComparing(ResolvedCoordinate::module)
             .thenComparing(ResolvedCoordinate::group);

--- a/src/main/java/com/palantir/gradle/versions/ResolvedCoordinate.java
+++ b/src/main/java/com/palantir/gradle/versions/ResolvedCoordinate.java
@@ -25,7 +25,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonSerialize(as = ImmutableResolvedCoordinate.class)
 @JsonDeserialize(as = ImmutableResolvedCoordinate.class)
-interface ResolvedCoordinate extends Serializable, Comparable<ResolvedCoordinate> {
+public interface ResolvedCoordinate extends Serializable, Comparable<ResolvedCoordinate> {
     Comparator<ResolvedCoordinate> COMPARATOR = Comparator.comparing(ResolvedCoordinate::configuration)
             .thenComparing(ResolvedCoordinate::module)
             .thenComparing(ResolvedCoordinate::group);

--- a/src/main/java/com/palantir/gradle/versions/WriteResolvedCoordinatesTask.java
+++ b/src/main/java/com/palantir/gradle/versions/WriteResolvedCoordinatesTask.java
@@ -21,12 +21,9 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
-import java.util.Set;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -39,19 +36,12 @@ public abstract class WriteResolvedCoordinatesTask extends DefaultTask {
     public abstract RegularFileProperty getOutputFile();
 
     @Input
-    public abstract MapProperty<String, Set<ResolvedComponentResult>> getConfigurationNameToAllComponents();
+    public abstract SetProperty<ResolvedCoordinate> getResolvedCoordinates();
 
     @TaskAction
     public final void writeResolvedCoordinates() {
-        List<ResolvedCoordinate> sorted = getConfigurationNameToAllComponents().get().entrySet().stream()
-                .flatMap(entry -> entry.getValue().stream()
-                        .map(ResolvedComponentResult::getId)
-                        .filter(ModuleComponentIdentifier.class::isInstance)
-                        .map(ModuleComponentIdentifier.class::cast)
-                        .map(mcid -> ResolvedCoordinate.of(entry.getKey(), mcid.getGroup(), mcid.getModule())))
-                .sorted()
-                .distinct()
-                .toList();
+        List<ResolvedCoordinate> sorted =
+                getResolvedCoordinates().get().stream().sorted().toList();
         try {
             OBJECT_MAPPER.writeValue(getOutputFile().get().getAsFile(), sorted);
         } catch (IOException e) {


### PR DESCRIPTION
## Before this PR

In large repos with many subprojects, `writeResolvedCoordinatesTask` OOMs the Gradle daemon. The task declares `MapProperty<String, Set<ResolvedComponentResult>>` as an `@Input`. When Gradle fingerprints this input for up-to-date checking, it recursively serialises the entire dependency resolution graph per configuration per subproject — not just the component IDs the task actually needs.

JFR profiling confirmed this: the dominant allocation path is `AbstractValueProcessor.gradleSerialized` → `ResolvedComponentResultSerializer.writeComponent` (recursive), with individual worker threads allocating 600MB–2.4GB each before the daemon is killed.

## After this PR

==COMMIT_MSG==
Fix `writeResolvedCoordinatesTask` OOM by extracting lightweight `ResolvedCoordinate` values in the provider instead of passing `ResolvedComponentResult` objects as task `@Input`. Gradle now fingerprints small string tuples instead of recursively serialising entire resolution graphs.
==COMMIT_MSG==

Tested on the failing repo and now passing, all UT still pass 

## Possible downsides?