### PR TITLE
Use `IncludedBuild` test framework API in `works_with_included_builds`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         classpath 'com.palantir.jakartapackagealignment:jakarta-package-alignment:0.6.0'
         classpath 'com.palantir.gradle.jdks:gradle-jdks:0.77.0'
         classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.26.0'
-        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.64.0'
+        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.65.0'
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.35.0'
         classpath 'com.palantir.gradle.failure-reports:gradle-failure-reports:1.18.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.89.0'

--- a/src/test/java/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationTest.java
+++ b/src/test/java/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationTest.java
@@ -418,47 +418,57 @@ class ConsistentVersionsPluginIntegrationTest {
             }
             """, repo.path());
 
-        SubProject innerA = includedBuild.subproject("innerA");
-        innerA.buildGradle().append("""
-            dependencies {
-                implementation 'org.slf4j:slf4j-api'
-                runtimeOnly 'ch.qos.logback:logback-classic:1.1.11' // brings in slf4j-api 1.7.22
-            }
-
-            publishing {
-                repositories {
-                    maven {
-                        url = "%s"
+        includedBuild
+                .subproject("innerA")
+                .buildGradle()
+                .append("""
+                    dependencies {
+                        implementation 'org.slf4j:slf4j-api'
+                        runtimeOnly 'ch.qos.logback:logback-classic:1.1.11' // brings in slf4j-api 1.7.22
                     }
-                }
 
-                publications {
-                    maven(MavenPublication) {
-                        from components.java
-                    }
-                }
-            }
-            """, repo.path()).plugins().add("java").add("maven-publish");
+                    publishing {
+                        repositories {
+                            maven {
+                                url = "%s"
+                            }
+                        }
 
-        SubProject innerB = includedBuild.subproject("innerB");
-        innerB.buildGradle().append("""
-            publishing {
-                repositories {
-                    maven {
-                        url = "%s"
+                        publications {
+                            maven(MavenPublication) {
+                                from components.java
+                            }
+                        }
                     }
-                }
+                    """, repo.path())
+                .plugins()
+                .add("java")
+                .add("maven-publish");
 
-                publications {
-                    maven(MavenPublication) {
-                        from components.java
+        includedBuild
+                .subproject("innerB")
+                .buildGradle()
+                .append("""
+                    publishing {
+                        repositories {
+                            maven {
+                                url = "%s"
+                            }
+                        }
+
+                        publications {
+                            maven(MavenPublication) {
+                                from components.java
+                            }
+                        }
                     }
-                }
-            }
-            dependencies {
-                implementation 'test-alignment:module-with-higher-version'
-            }
-            """, repo.path()).plugins().add("java").add("maven-publish");
+                    dependencies {
+                        implementation 'test-alignment:module-with-higher-version'
+                    }
+                    """, repo.path())
+                .plugins()
+                .add("java")
+                .add("maven-publish");
 
         includedBuild.propertiesFile("versions.props").append("""
             org.slf4j:slf4j-api = 1.7.25

--- a/src/test/java/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationTest.java
+++ b/src/test/java/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationTest.java
@@ -403,7 +403,6 @@ class ConsistentVersionsPluginIntegrationTest {
     }
 
     @Test
-    @SuppressWarnings("MethodLength")
     @DisabledConfigurationCache("configuration cache cannot be reused due to --write-locks")
     void works_with_included_builds(
             GradleInvoker gradle, RootProject rootProject, IncludedBuild includedBuild, MavenRepo repo) {

--- a/src/test/java/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationTest.java
+++ b/src/test/java/com/palantir/gradle/versions/ConsistentVersionsPluginIntegrationTest.java
@@ -26,6 +26,7 @@ import com.palantir.gradle.testing.junit.DisabledConfigurationCache;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.maven.MavenArtifact;
 import com.palantir.gradle.testing.maven.MavenRepo;
+import com.palantir.gradle.testing.project.IncludedBuild;
 import com.palantir.gradle.testing.project.RootProject;
 import com.palantir.gradle.testing.project.SubProject;
 import java.io.IOException;
@@ -404,105 +405,66 @@ class ConsistentVersionsPluginIntegrationTest {
     @Test
     @SuppressWarnings("MethodLength")
     @DisabledConfigurationCache("configuration cache cannot be reused due to --write-locks")
-    void works_with_included_builds(GradleInvoker gradle, RootProject rootProject, MavenRepo repo) {
-        // add included build
-        Path includedBuild = rootProject.directory("included-build").path();
-        rootProject.settingsGradle().append("""
-            includeBuild 'included-build'
+    void works_with_included_builds(
+            GradleInvoker gradle, RootProject rootProject, IncludedBuild includedBuild, MavenRepo repo) {
+        includedBuild.buildGradle().plugins().add(PLUGIN_NAME);
+        includedBuild.buildGradle().append("""
+            allprojects {
+                group 'com.palantir.includedBuild'
+                version '1.0.0'
+
+                repositories {
+                    maven { url uri("%s") }
+                }
+            }
+            """, repo.path());
+
+        SubProject innerA = includedBuild.subproject("innerA");
+        innerA.buildGradle().append("""
+            dependencies {
+                implementation 'org.slf4j:slf4j-api'
+                runtimeOnly 'ch.qos.logback:logback-classic:1.1.11' // brings in slf4j-api 1.7.22
+            }
+
+            publishing {
+                repositories {
+                    maven {
+                        url = "%s"
+                    }
+                }
+
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+            """, repo.path()).plugins().add("java").add("maven-publish");
+
+        SubProject innerB = includedBuild.subproject("innerB");
+        innerB.buildGradle().append("""
+            publishing {
+                repositories {
+                    maven {
+                        url = "%s"
+                    }
+                }
+
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+            dependencies {
+                implementation 'test-alignment:module-with-higher-version'
+            }
+            """, repo.path()).plugins().add("java").add("maven-publish");
+
+        includedBuild.propertiesFile("versions.props").append("""
+            org.slf4j:slf4j-api = 1.7.25
+            test-alignment:* = 1.1
             """);
-
-        // configure the included build
-        rootProject
-                .directory(includedBuild.toString())
-                .gradleFile("settings.gradle")
-                .append("""
-                    rootProject.name = 'included-build'
-
-                    include 'innerA'
-                    include 'innerB'
-                    """);
-
-        rootProject
-                .directory(includedBuild.toString())
-                .gradleFile("build.gradle")
-                .plugins()
-                .add(PLUGIN_NAME);
-
-        rootProject
-                .directory(includedBuild.toString())
-                .gradleFile("build.gradle")
-                .append("""
-                    allprojects {
-                        group 'com.palantir.included-build'
-                        version '1.0.0'
-
-                        repositories {
-                            maven { url uri("%s") }
-                        }
-                    }
-                    """, repo.path());
-
-        Path innerA = includedBuild.resolve("innerA");
-        rootProject
-                .directory(innerA.toString())
-                .gradleFile("build.gradle")
-                .append("""
-                    dependencies {
-                        implementation 'org.slf4j:slf4j-api'
-                        runtimeOnly 'ch.qos.logback:logback-classic:1.1.11' // brings in slf4j-api 1.7.22
-                    }
-
-                    publishing {
-                        repositories {
-                            maven {
-                                url = "%s"
-                            }
-                        }
-
-                        publications {
-                            maven(MavenPublication) {
-                                from components.java
-                            }
-                        }
-                    }
-                    """, repo.path())
-                .plugins()
-                .add("java")
-                .add("maven-publish");
-
-        Path innerB = includedBuild.resolve("innerB");
-        rootProject
-                .directory(innerB.toString())
-                .gradleFile("build.gradle")
-                .append("""
-                    publishing {
-                        repositories {
-                            maven {
-                                url = "%s"
-                            }
-                        }
-
-                        publications {
-                            maven(MavenPublication) {
-                                from components.java
-                            }
-                        }
-                    }
-                    dependencies {
-                        implementation 'test-alignment:module-with-higher-version'
-                    }
-                    """, repo.path())
-                .plugins()
-                .add("java")
-                .add("maven-publish");
-
-        rootProject
-                .directory(includedBuild.toString())
-                .propertiesFile("versions.props")
-                .append("""
-                    org.slf4j:slf4j-api = 1.7.25
-                    test-alignment:* = 1.1
-                    """);
 
         // configure main build
         rootProject.buildGradle().plugins().add("java");
@@ -537,19 +499,15 @@ class ConsistentVersionsPluginIntegrationTest {
 
         gradle.withArgs("--write-locks").buildsSuccessfully();
 
-        assertThat(rootProject
-                        .directory(includedBuild.toString())
-                        .file("versions.lock")
-                        .text())
-                .isEqualTo("""
-                    # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
+        assertThat(includedBuild.file("versions.lock").text()).isEqualTo("""
+            # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
 
-                    ch.qos.logback:logback-classic:1.1.11 (1 constraints: 36052a3b)
+            ch.qos.logback:logback-classic:1.1.11 (1 constraints: 36052a3b)
 
-                    org.slf4j:slf4j-api:1.7.25 (2 constraints: 7d12a137)
+            org.slf4j:slf4j-api:1.7.25 (2 constraints: 7d12a137)
 
-                    test-alignment:module-with-higher-version:1.1 (1 constraints: a6041b2c)
-                    """);
+            test-alignment:module-with-higher-version:1.1 (1 constraints: a6041b2c)
+            """);
 
         assertThat(rootProject.file("versions.lock").text()).isEqualTo("""
             # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
@@ -560,8 +518,8 @@ class ConsistentVersionsPluginIntegrationTest {
         // we add a dependencies on the inner build
         rootProject.buildGradle().append("""
             dependencies {
-              implementation 'com.palantir.included-build:innerA'
-              implementation 'com.palantir.included-build:innerB'
+              implementation 'com.palantir.includedBuild:innerA'
+              implementation 'com.palantir.includedBuild:innerB'
             }
             """);
 
@@ -570,8 +528,8 @@ class ConsistentVersionsPluginIntegrationTest {
 
         gradle.withArgs(
                         ":publishMavenPublicationToMavenRepository",
-                        ":included-build:innerA:publishMavenPublicationToMavenRepository",
-                        ":included-build:innerB:publishMavenPublicationToMavenRepository")
+                        ":includedBuild:innerA:publishMavenPublicationToMavenRepository",
+                        ":includedBuild:innerB:publishMavenPublicationToMavenRepository")
                 .buildsSuccessfully();
 
         // root build: dependency is bumped - there is a difference in resolution between Gradle versions hence why we

--- a/versions.lock
+++ b/versions.lock
@@ -44,13 +44,13 @@ cglib:cglib-nodep:3.2.2 (1 constraints: 490ded24)
 
 com.netflix.nebula:nebula-test:10.6.2 (2 constraints: d61de72d)
 
-com.palantir.gradle.plugintesting:configuration-cache-spec:0.64.0 (1 constraints: 3c05433b)
+com.palantir.gradle.plugintesting:configuration-cache-spec:0.65.0 (1 constraints: 3d05463b)
 
-com.palantir.gradle.plugintesting:discover-tests-cli:0.64.0 (1 constraints: 3c05433b)
+com.palantir.gradle.plugintesting:discover-tests-cli:0.65.0 (1 constraints: 3d05463b)
 
-com.palantir.gradle.plugintesting:gradle-plugin-testing-junit:0.64.0 (1 constraints: a8076f7e)
+com.palantir.gradle.plugintesting:gradle-plugin-testing-junit:0.65.0 (1 constraints: a907737e)
 
-com.palantir.gradle.plugintesting:plugin-testing-core:0.64.0 (1 constraints: 3c05433b)
+com.palantir.gradle.plugintesting:plugin-testing-core:0.65.0 (1 constraints: 3d05463b)
 
 commons-io:commons-io:2.19.0 (1 constraints: db190cdf)
 


### PR DESCRIPTION
## Before this PR

The `works_with_included_builds` test manually set up its composite build by creating directories, appending `includeBuild` to `settings.gradle`, and using `rootProject.directory(path)` to configure the included build's files. 

## After this PR

Uses the `IncludedBuild` test framework API which handles directory creation, `settings.gradle` registration, and subproject includes automatically. 

Also bumps `gradle-plugin-testing` from 0.64.0 to 0.65.0 which includes the `IncludedBuild` parameter injection support.

## Possible downsides?

## Test plan
