### PR TITLE
Exclude gcvGetVersions configuration in CheckUnusedConstraintsProjectPlugin

### DIFF
--- a/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/CheckUnusedConstraintsProjectPlugin.java
@@ -54,7 +54,11 @@ public abstract class CheckUnusedConstraintsProjectPlugin implements Plugin<Proj
     public final void apply(Project project) {
         Provider<List<Configuration>> configurationsToCheck = getProviderFactory()
                 .provider(() -> GradleConfigurations.getResolvableConfigurations(project).stream()
-                        .filter(configuration -> !configuration.getName().startsWith("checkUnusedConstraints"))
+                        .filter(configuration -> {
+                            String name = configuration.getName();
+                            return !(name.startsWith("checkUnusedConstraints")
+                                    || name.equals(GetVersionPlugin.GET_VERSIONS_CONFIGURATION_NAME));
+                        })
                         .toList());
 
         Provider<Set<ResolvedCoordinate>> resolvedCoordinates =

--- a/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java
@@ -47,7 +47,7 @@ public abstract class GetVersionPlugin implements Plugin<Project> {
 
     private static final Logger log = Logging.getLogger(GetVersionPlugin.class);
     private static final GradleVersion GRADLE_9 = GradleVersion.version("9.0");
-    private static final String GET_VERSIONS_CONFIGURATION_NAME = "gcvGetVersions";
+    static final String GET_VERSIONS_CONFIGURATION_NAME = "gcvGetVersions";
 
     @Nested
     protected abstract GcvAttributes getAttributes();


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

`writeResolvedCoordinatesTask` OOMs the gradle worker locally. 

`CheckUnusedConstraintsProjectPlugin` used to get the dependencies from `gcvGetVersions` in local projects, but that configuration's dependencies are explicitly the whole project again:
https://github.com/palantir/gradle-consistent-versions/blob/c4a1a78e018eb4fc14886f58f151e84eb5133cef/src/main/java/com/palantir/gradle/versions/GetVersionPlugin.java#L70-L74

 so each local project walks the root project's entire dependency tree.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Exclude gcvGetVersions configuration in CheckUnusedConstraintsProjectPlugin
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

